### PR TITLE
feat: Add comma to the Difficulty value of the Block page

### DIFF
--- a/src/pages/BlockDetail/index.tsx
+++ b/src/pages/BlockDetail/index.tsx
@@ -393,7 +393,7 @@ export default (props: React.PropsWithoutRef<RouteComponentProps<{ hash: string 
     {
       image: DifficultyIcon,
       label: 'Difficulty:',
-      value: `${parseInt(state.block.difficulty, 16)}`,
+      value: parseInt(state.block.difficulty, 16).toLocaleString(),
     },
     {
       image: NonceIcon,


### PR DESCRIPTION
It is the same as the Difficulty display on the home page.