### PR TITLE
chore: Fix transaction cell issues

### DIFF
--- a/src/pages/Transaction/TransactionCell/index.tsx
+++ b/src/pages/Transaction/TransactionCell/index.tsx
@@ -99,10 +99,6 @@ export default ({
   cellType: CellType
   dispatch: AppDispatch
 }) => {
-  let highLight = false
-  if (cell.address_hash && cell.address_hash.length > 0) {
-    highLight = true
-  }
   const [state, setState] = useState(CellState.NONE as CellState)
 
   if (isMobile()) {
@@ -112,15 +108,15 @@ export default ({
         content: <TransactionCellHash cell={cell} />,
       },
     ]
-    if (cell.capacity) {
-      items.push({
-        title: i18n.t('transaction.capacity'),
-        content: cell.capacity && localeNumberString(shannonToCkb(cell.capacity)),
-      })
-    }
+    items.push({
+      title: i18n.t('transaction.capacity'),
+      content: localeNumberString(shannonToCkb(cell.capacity || 0)),
+    })
     return (
       <OverviewCard items={items}>
-        {highLight && <TransactionCellDetailButtons highLight={highLight} onChange={newState => setState(newState)} />}
+        {!cell.from_cellbase && (
+          <TransactionCellDetailButtons highLight={!cell.from_cellbase} onChange={newState => setState(newState)} />
+        )}
         {state !== CellState.NONE && (
           <TransactionCellDetail cell={cell} cellType={cellType} state={state} dispatch={dispatch} />
         )}
@@ -138,7 +134,7 @@ export default ({
           {cell.capacity && localeNumberString(shannonToCkb(cell.capacity))}
         </div>
         <div className="transaction__cell_detail">
-          <TransactionCellDetailButtons highLight={highLight} onChange={newState => setState(newState)} />
+          <TransactionCellDetailButtons highLight={!cell.from_cellbase} onChange={newState => setState(newState)} />
         </div>
       </TransactionCellContentPanel>
       {state !== CellState.NONE && (

--- a/src/pages/Transaction/TransactionCell/index.tsx
+++ b/src/pages/Transaction/TransactionCell/index.tsx
@@ -108,10 +108,12 @@ export default ({
         content: <TransactionCellHash cell={cell} />,
       },
     ]
-    items.push({
-      title: i18n.t('transaction.capacity'),
-      content: localeNumberString(shannonToCkb(cell.capacity || 0)),
-    })
+    if (cell.capacity) {
+      items.push({
+        title: i18n.t('transaction.capacity'),
+        content: cell.capacity && localeNumberString(shannonToCkb(cell.capacity)),
+      })
+    }
     return (
       <OverviewCard items={items}>
         {!cell.from_cellbase && (


### PR DESCRIPTION
When the `cell` type is not `cellbase`, the `details` button can be click.