### PR TITLE
[ᚬaggron] Update balance distribution tooltip width

### DIFF
--- a/src/pages/StatisticsChart/BalanceDistribution.tsx
+++ b/src/pages/StatisticsChart/BalanceDistribution.tsx
@@ -40,7 +40,7 @@ const getOption = (statisticBalanceDistributions: State.StatisticBalanceDistribu
         const colorSpan = (color: string) =>
           `<span style="display:inline-block;margin-right:8px;margin-left:5px;margin-bottom:2px;border-radius:10px;width:6px;height:6px;background-color:${color}"></span>`
         const widthSpan = (value: string) =>
-          `<span style="width:${currentLanguage() === 'en' ? 280 : 110}px;display:inline-block;">${value}:</span>`
+          `<span style="width:${currentLanguage() === 'en' ? 350 : 110}px;display:inline-block;">${value}:</span>`
         let result = `<div>${colorSpan('#333333')}${widthSpan(i18n.t('statistic.addresses_balance'))} ${handleGroupAxis(
           new BigNumber(dataList[0].name),
           dataList[0].dataIndex === statisticBalanceDistributions.length - 1 ? '+' : '',


### PR DESCRIPTION
Because of monspace font of aggron explorer, balance distribution chart tooltip width should be set more bigger.