### PR TITLE
Fix cell info modal controller bug

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,12 +1,19 @@
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode } from 'react'
 import OutsideClickHandler from 'react-outside-click-handler'
 import { ModalPanel } from './styled'
 
-const SimpleModal = ({ children, isShow }: { children: ReactNode; isShow: boolean }) => {
-  const [innerShow, setInnerShow] = useState(true)
-  return isShow && innerShow ? (
+const SimpleModal = ({
+  children,
+  isShow,
+  setIsShow,
+}: {
+  children: ReactNode
+  isShow: boolean
+  setIsShow: Function
+}) => {
+  return isShow ? (
     <ModalPanel>
-      <OutsideClickHandler onOutsideClick={() => setInnerShow(false)}>{children}</OutsideClickHandler>
+      <OutsideClickHandler onOutsideClick={() => setIsShow(false)}>{children}</OutsideClickHandler>
     </ModalPanel>
   ) : null
 }

--- a/src/pages/Transaction/TransactionCell/index.tsx
+++ b/src/pages/Transaction/TransactionCell/index.tsx
@@ -150,7 +150,7 @@ const TransactionCellInfo = ({ cell, children }: { cell: State.Cell; children: s
         children={children}
       />
       <div className="transaction__cell__info__separate" />
-      <SimpleModal isShow={showModal}>
+      <SimpleModal isShow={showModal} setIsShow={setShowModal}>
         <TransactionCellDetailModal>
           <TransactionCellScript cell={cell} onClose={() => setShowModal(false)} />
         </TransactionCellDetailModal>


### PR DESCRIPTION
The controller of the cell info modal should be uniformly configured outside the component to avoid mutual interference. And the bug is caused by two controllers of inside and outside.