### PR TITLE
fix: update hardfork info only in mainnet

### DIFF
--- a/src/service/app/statistics.ts
+++ b/src/service/app/statistics.ts
@@ -4,6 +4,9 @@ import { AppActions, PageActions } from '../../contexts/actions'
 import { NEXT_HARD_FORK_EPOCH, EPOCH_HOURS } from '../../constants/common'
 import { storeCachedData } from '../../utils/cache'
 import { AppCachedKeys } from '../../constants/cache'
+import { isMainnet as isMainnetFunc } from '../../utils/chain'
+
+const isMainnet = isMainnetFunc()
 
 export const getStatistics = (dispatch: AppDispatch) => {
   return fetchStatistics().then((wrapper: Response.Wrapper<State.Statistics> | null) => {
@@ -14,17 +17,19 @@ export const getStatistics = (dispatch: AppDispatch) => {
           statistics: wrapper.attributes,
         },
       })
-      const { epochNumber, index, epochLength } = wrapper.attributes.epochInfo
-      const hs = (NEXT_HARD_FORK_EPOCH - (+epochNumber + +index / +epochLength)) * EPOCH_HOURS * 60 * 60
-      const hardForkInfo = {
-        miranaHardForkSecondsLeft: Math.floor(hs),
-        hasFinishedHardFork: hs <= 0,
+      if (isMainnet) {
+        const { epochNumber, index, epochLength } = wrapper.attributes.epochInfo
+        const hs = (NEXT_HARD_FORK_EPOCH - (+epochNumber + +index / +epochLength)) * EPOCH_HOURS * 60 * 60
+        const hardForkInfo = {
+          miranaHardForkSecondsLeft: Math.floor(hs),
+          hasFinishedHardFork: hs <= 0,
+        }
+        storeCachedData(AppCachedKeys.HardForkInfo, hardForkInfo)
+        dispatch({
+          type: AppActions.UpdateHardForkStatus,
+          payload: hardForkInfo,
+        })
       }
-      storeCachedData(AppCachedKeys.HardForkInfo, hardForkInfo)
-      dispatch({
-        type: AppActions.UpdateHardForkStatus,
-        payload: hardForkInfo,
-      })
     }
   })
 }


### PR DESCRIPTION
Data from testnet API are not suitable for hardfork info