### PR TITLE
fix: check args length on transforming into short version address

### DIFF
--- a/src/utils/hook.ts
+++ b/src/utils/hook.ts
@@ -85,13 +85,15 @@ export const useDeprecatedAddr = (addr: string) =>
     if (addr.startsWith('0x')) {
       return null
     }
+    const BLAKE160_ARGS_LENGTH = 42
     try {
       const isMainnet = addr.startsWith('ckb')
       const prefix = isMainnet ? AddressPrefix.Mainnet : AddressPrefix.Testnet
       const script = addressToScript(addr)
       switch (true) {
         case script.codeHash === systemScripts.SECP256K1_BLAKE160.codeHash &&
-          script.hashType === systemScripts.SECP256K1_BLAKE160.hashType: {
+          script.hashType === systemScripts.SECP256K1_BLAKE160.hashType &&
+          script.args.length === BLAKE160_ARGS_LENGTH: {
           return bech32Address(script.args, {
             prefix,
             type: AddressType.HashIdx,
@@ -99,7 +101,8 @@ export const useDeprecatedAddr = (addr: string) =>
           })
         }
         case script.codeHash === systemScripts.SECP256K1_MULTISIG.codeHash &&
-          script.hashType === systemScripts.SECP256K1_MULTISIG.hashType: {
+          script.hashType === systemScripts.SECP256K1_MULTISIG.hashType &&
+          script.args.length === BLAKE160_ARGS_LENGTH: {
           return bech32Address(script.args, {
             prefix,
             type: AddressType.HashIdx,
@@ -108,6 +111,7 @@ export const useDeprecatedAddr = (addr: string) =>
         }
         case script.codeHash === systemScripts.ANYONE_CAN_PAY_MAINNET.codeHash &&
           script.hashType === systemScripts.ANYONE_CAN_PAY_MAINNET.hashType &&
+          script.args.length === BLAKE160_ARGS_LENGTH &&
           isMainnet: {
           return bech32Address(script.args, {
             prefix,
@@ -117,6 +121,7 @@ export const useDeprecatedAddr = (addr: string) =>
         }
         case script.codeHash === systemScripts.ANYONE_CAN_PAY_TESTNET.codeHash &&
           script.hashType === systemScripts.ANYONE_CAN_PAY_TESTNET.hashType &&
+          script.args.length === BLAKE160_ARGS_LENGTH &&
           !isMainnet: {
           return bech32Address(script.args, {
             prefix,


### PR DESCRIPTION
length of short payload's args is limited to 20bytes according to [RFC](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0021-ckb-address-format/0021-ckb-address-format.md)

before
![image](https://user-images.githubusercontent.com/7271329/172212735-91902051-671e-457b-8cb8-4892c6bec5b1.png)
after
![image](https://user-images.githubusercontent.com/7271329/172212764-2c2d4253-231c-431c-b397-f480251af9c9.png)
