### PR TITLE
feat: update charts related to epochs

### DIFF
--- a/src/pages/StatisticsChart/mining/DifficultyHashRate.tsx
+++ b/src/pages/StatisticsChart/mining/DifficultyHashRate.tsx
@@ -120,7 +120,7 @@ const getOption = (
       type: 'line',
       step: 'start',
       areaStyle: {
-        color: chartColor.areaColor,
+        color: chartColor.colors[0],
       },
       yAxisIndex: 0,
       symbol: isThumbnail ? 'none' : 'circle',
@@ -131,6 +131,9 @@ const getOption = (
       name: i18n.t('block.hash_rate_hps'),
       type: 'line',
       smooth: true,
+      areaStyle: {
+        color: chartColor.colors[1],
+      },
       yAxisIndex: 1,
       symbol: isThumbnail ? 'none' : 'circle',
       symbolSize: 3,

--- a/src/pages/StatisticsChart/mining/DifficultyUncleRateEpoch.tsx
+++ b/src/pages/StatisticsChart/mining/DifficultyUncleRateEpoch.tsx
@@ -164,10 +164,11 @@ const getOption = (
   series: [
     {
       name: i18n.t('block.difficulty'),
-      type: 'bar',
+      type: 'line',
       step: 'start',
       areaStyle: {
-        color: chartColor.areaColor,
+        opacity: 0.3,
+        color: chartColor.moreColors[0],
       },
       yAxisIndex: 0,
       symbol: isThumbnail ? 'none' : 'circle',
@@ -202,9 +203,10 @@ const getOption = (
     },
     {
       name: i18n.t('block.epoch_time'),
-      type: 'bar',
+      type: 'line',
       step: 'start',
       areaStyle: {
+        opacity: 0.3,
         color: chartColor.moreColors[2],
       },
       yAxisIndex: 2,
@@ -214,9 +216,10 @@ const getOption = (
     },
     {
       name: i18n.t('block.epoch_length'),
-      type: 'bar',
+      type: 'line',
       step: 'start',
       areaStyle: {
+        opacity: 0.3,
         color: chartColor.moreColors[3],
       },
       yAxisIndex: 3,

--- a/src/service/app/charts/mining.ts
+++ b/src/service/app/charts/mining.ts
@@ -76,8 +76,7 @@ export const getStatisticDifficultyUncleRateEpoch = (dispatch: AppDispatch) => {
         epochTime: wrapper.attributes.epochTime,
         epochLength: wrapper.attributes.epochLength,
       }))
-      const dispatchData = difficultyUncleRateEpochs
-      dispatchDifficultyUncleRateEpoch(dispatch, dispatchData)
+      dispatchDifficultyUncleRateEpoch(dispatch, difficultyUncleRateEpochs)
       if (difficultyUncleRateEpochs && difficultyUncleRateEpochs.length > 0) {
         storeEpochChartCache(ChartCachedKeys.DifficultyUncleRateEpoch, difficultyUncleRateEpochs)
       }

--- a/src/service/app/charts/mining.ts
+++ b/src/service/app/charts/mining.ts
@@ -25,7 +25,6 @@ import {
   dispatchDifficultyHashRate,
   dispatchDifficultyUncleRateEpoch,
 } from './action'
-import { isMobile } from '../../../utils/screen'
 
 export const getStatisticDifficultyHashRate = (dispatch: AppDispatch) => {
   const data = fetchEpochChartCache(ChartCachedKeys.DifficultyHashRate)
@@ -57,30 +56,27 @@ export const getStatisticDifficultyHashRate = (dispatch: AppDispatch) => {
     })
 }
 
-const sliceStatistics = (data: Array<State.StatisticDifficultyUncleRateEpoch>) =>
-  data.slice(isMobile() ? Math.ceil(data.length / 2) : 0)
-
 export const getStatisticDifficultyUncleRateEpoch = (dispatch: AppDispatch) => {
   const data = fetchEpochChartCache(
     ChartCachedKeys.DifficultyUncleRateEpoch,
   ) as State.StatisticDifficultyUncleRateEpoch[]
 
   if (data) {
-    dispatchDifficultyUncleRateEpoch(dispatch, sliceStatistics(data))
+    dispatchDifficultyUncleRateEpoch(dispatch, data)
     return
   }
   fetchStatisticDifficultyUncleRateEpoch()
     .then((response: Response.Response<Response.Wrapper<State.StatisticDifficultyUncleRateEpoch>[]> | null) => {
       if (!response) return
       const { data } = response
-      const difficultyUncleRateEpochs = data.slice(Math.ceil(data.length / 2)).map(wrapper => ({
+      const difficultyUncleRateEpochs = data.map(wrapper => ({
         epochNumber: wrapper.attributes.epochNumber,
         difficulty: wrapper.attributes.difficulty,
         uncleRate: new BigNumber(wrapper.attributes.uncleRate).toFixed(4),
         epochTime: wrapper.attributes.epochTime,
         epochLength: wrapper.attributes.epochLength,
       }))
-      const dispatchData = sliceStatistics(difficultyUncleRateEpochs)
+      const dispatchData = difficultyUncleRateEpochs
       dispatchDifficultyUncleRateEpoch(dispatch, dispatchData)
       if (difficultyUncleRateEpochs && difficultyUncleRateEpochs.length > 0) {
         storeEpochChartCache(ChartCachedKeys.DifficultyUncleRateEpoch, difficultyUncleRateEpochs)


### PR DESCRIPTION
1. show all records instead of truncating the a half

![Pasted Graphic 17](https://user-images.githubusercontent.com/7271329/179147050-708851ab-1539-462d-b963-2d87220a671c.png)
Left: Before, Right: After


2. fix colors of Difficulty & Hash Rate
![Pasted Graphic 15](https://user-images.githubusercontent.com/7271329/179147206-0b016c74-5144-4920-806b-da147b70cffd.png)
Left: Before, Right: After


3. adjust chart style of Difficulty & Uncle Rate & Epoch Time & Epoch
   Length
![Pasted Graphic 16](https://user-images.githubusercontent.com/7271329/179147255-73102e06-0fda-44ed-bd71-88f3bf269e90.png)
Left: Before, Right: After
