### PR TITLE
feat: update charts of uncle rate and epoch time/length

### DIFF
--- a/src/pages/StatisticsChart/index.tsx
+++ b/src/pages/StatisticsChart/index.tsx
@@ -128,14 +128,14 @@ const chartsData = (): ChartCategory[] => [
     category: i18n.t('statistic.category_mining'),
     charts: [
       {
-        title: `${i18n.t('block.difficulty')} & ${i18n.t('block.hash_rate')}`,
+        title: `${i18n.t('block.difficulty')} & ${i18n.t('block.hash_rate')} & ${i18n.t('block.uncle_rate')}`,
         chart: <DifficultyHashRateChart isThumbnail />,
         path: '/charts/difficulty-hash-rate',
       },
       {
-        title: `${i18n.t('block.difficulty')} & ${i18n.t('block.uncle_rate')} & ${i18n.t('block.epoch_time')} & ...`,
+        title: `${i18n.t('block.epoch_time')} & ${i18n.t('block.epoch_length')}`,
         chart: <DifficultyUncleRateEpochChart isThumbnail />,
-        path: '/charts/difficulty-uncle-rate',
+        path: '/charts/epoch-time-length',
       },
       {
         title: `${i18n.t('block.difficulty')}`,

--- a/src/pages/StatisticsChart/mining/DifficultyHashRate.tsx
+++ b/src/pages/StatisticsChart/mining/DifficultyHashRate.tsx
@@ -26,6 +26,9 @@ const grid = () => ({
 const widthSpan = (value: string) => tooltipWidth(value, currentLanguage() === 'en' ? 70 : 50)
 
 const parseTooltip = ({ seriesName, data, color }: SeriesItem & { data: string }): string => {
+  if (seriesName === i18n.t('block.uncle_rate')) {
+    return `<div>${tooltipColor(color)}${widthSpan(i18n.t('block.uncle_rate'))} ${data}%</div>`
+  }
   if (seriesName === i18n.t('block.difficulty')) {
     return `<div>${tooltipColor(color)}${widthSpan(i18n.t('block.difficulty'))} ${handleDifficulty(data)}</div>`
   }
@@ -40,7 +43,7 @@ const getOption = (
   chartColor: State.App['chartColor'],
   isThumbnail = false,
 ): echarts.EChartOption => ({
-  color: chartColor.colors,
+  color: chartColor.moreColors,
   tooltip: !isThumbnail
     ? {
         trigger: 'axis',
@@ -62,6 +65,9 @@ const getOption = (
           },
           {
             name: i18n.t('block.hash_rate_hps'),
+          },
+          {
+            name: i18n.t('block.uncle_rate'),
           },
         ],
       }
@@ -89,7 +95,7 @@ const getOption = (
       scale: true,
       axisLine: {
         lineStyle: {
-          color: chartColor.colors[0],
+          color: chartColor.moreColors[0],
         },
       },
       axisLabel: {
@@ -103,14 +109,23 @@ const getOption = (
       splitLine: {
         show: false,
       },
-      scale: true,
       axisLine: {
         lineStyle: {
-          color: chartColor.colors[1],
+          color: chartColor.moreColors[1],
         },
       },
+      scale: true,
       axisLabel: {
         formatter: (value: string) => handleAxis(new BigNumber(value)),
+      },
+    },
+    {
+      position: 'right',
+      type: 'value',
+      max: 100,
+      show: false,
+      axisLabel: {
+        formatter: () => '',
       },
     },
   ],
@@ -118,10 +133,6 @@ const getOption = (
     {
       name: i18n.t('block.difficulty'),
       type: 'line',
-      step: 'start',
-      areaStyle: {
-        color: chartColor.colors[0],
-      },
       yAxisIndex: 0,
       symbol: isThumbnail ? 'none' : 'circle',
       symbolSize: 3,
@@ -130,14 +141,34 @@ const getOption = (
     {
       name: i18n.t('block.hash_rate_hps'),
       type: 'line',
-      smooth: true,
-      areaStyle: {
-        color: chartColor.colors[1],
-      },
       yAxisIndex: 1,
       symbol: isThumbnail ? 'none' : 'circle',
       symbolSize: 3,
       data: statisticDifficultyHashRates.map(data => new BigNumber(data.hashRate).toNumber()),
+    },
+    {
+      name: i18n.t('block.uncle_rate'),
+      type: 'line',
+      smooth: true,
+      yAxisIndex: 2,
+      symbol: isThumbnail ? 'none' : 'circle',
+      symbolSize: 3,
+      z: 0,
+      markLine: isThumbnail
+        ? undefined
+        : {
+            symbol: 'none',
+            data: [
+              {
+                name: i18n.t('block.uncle_rate_target'),
+                yAxis: 2.5,
+              },
+            ],
+            label: {
+              formatter: (params: any) => `${params.value}%`,
+            },
+          },
+      data: statisticDifficultyHashRates.map(data => (Number(data.uncleRate) * 100).toFixed(2)),
     },
   ],
 })
@@ -156,7 +187,7 @@ export const DifficultyHashRateChart = ({ isThumbnail = false }: { isThumbnail?:
 
 const toCSV = (statisticDifficultyHashRates: State.StatisticDifficultyHashRate[]) =>
   statisticDifficultyHashRates
-    ? statisticDifficultyHashRates.map(data => [data.epochNumber, data.difficulty, data.hashRate])
+    ? statisticDifficultyHashRates.map(data => [data.epochNumber, data.difficulty, data.hashRate, data.uncleRate])
     : []
 
 export default () => {
@@ -169,7 +200,7 @@ export default () => {
 
   return (
     <ChartPage
-      title={`${i18n.t('block.difficulty')} & ${i18n.t('block.hash_rate')}`}
+      title={`${i18n.t('block.difficulty')} & ${i18n.t('block.hash_rate')} & ${i18n.t('block.uncle_rate')}`}
       data={toCSV(statisticDifficultyHashRates)}
     >
       <DifficultyHashRateChart />

--- a/src/pages/StatisticsChart/mining/DifficultyUncleRateEpoch.tsx
+++ b/src/pages/StatisticsChart/mining/DifficultyUncleRateEpoch.tsx
@@ -3,8 +3,7 @@ import BigNumber from 'bignumber.js'
 import { getStatisticDifficultyUncleRateEpoch } from '../../../service/app/charts/mining'
 import { useAppState, useDispatch } from '../../../contexts/providers'
 import i18n, { currentLanguage } from '../../../utils/i18n'
-import { DATA_ZOOM_CONFIG, handleAxis } from '../../../utils/chart'
-import { handleDifficulty } from '../../../utils/number'
+import { handleAxis } from '../../../utils/chart'
 import { isMobile } from '../../../utils/screen'
 import { ChartLoading, ReactChartCore, ChartPage, tooltipColor, tooltipWidth, SeriesItem } from '../common'
 import { parseHourFromMillisecond } from '../../../utils/date'
@@ -24,20 +23,9 @@ const grid = {
   containLabel: true,
 }
 
-const max = (statisticChartData: State.StatisticDifficultyUncleRateEpoch[]) => {
-  const array = statisticChartData.flatMap(data => Number(data.uncleRate) * 100)
-  return Math.max(5, Math.ceil(Math.max(...array)))
-}
-
 const widthSpan = (value: string) => tooltipWidth(value, currentLanguage() === 'en' ? 90 : 80)
 
 const parseTooltip = ({ seriesName, data, color }: SeriesItem & { data: string }) => {
-  if (seriesName === i18n.t('block.difficulty')) {
-    return `<div>${tooltipColor(color)}${widthSpan(i18n.t('block.difficulty'))} ${handleDifficulty(data)}</div>`
-  }
-  if (seriesName === i18n.t('block.uncle_rate')) {
-    return `<div>${tooltipColor(color)}${widthSpan(i18n.t('block.uncle_rate'))} ${data}%</div>`
-  }
   if (seriesName === i18n.t('block.epoch_time')) {
     return `<div>${tooltipColor(color)}${widthSpan(i18n.t('block.epoch_time'))} ${data} h</div>`
   }
@@ -51,184 +39,153 @@ const getOption = (
   statisticChartData: State.StatisticDifficultyUncleRateEpoch[],
   chartColor: State.App['chartColor'],
   isThumbnail = false,
-) => ({
-  color: chartColor.moreColors,
-  tooltip: !isThumbnail
-    ? {
-        trigger: 'axis',
-        formatter: (dataList: any) => {
-          const list = dataList as Array<SeriesItem & { data: string }>
-          let result = `<div>${tooltipColor('#333333')}${widthSpan(i18n.t('block.epoch'))} ${list[0].name}</div>`
-          list.forEach(data => {
-            result += parseTooltip(data)
-          })
-          return result
-        },
-      }
-    : undefined,
-  legend: !isThumbnail
-    ? {
-        data: [
+) => {
+  const COUNT_IN_THUMBNAIL = 90
+  const epochNumberSerie = statisticChartData.map(data => data.epochNumber)
+  const epochTimeSerie = statisticChartData.map(data => parseHourFromMillisecond(data.epochTime))
+  const epochLengthSerie = statisticChartData.map(data => data.epochLength)
+  const endValue = statisticChartData[statisticChartData.length - 1]?.epochNumber ?? '0'
+  const startValue = Math.max(+endValue - COUNT_IN_THUMBNAIL, 0).toString()
+
+  return {
+    color: chartColor.moreColors,
+    tooltip: !isThumbnail
+      ? {
+          trigger: 'axis',
+          formatter: (dataList: any) => {
+            const list = dataList as Array<SeriesItem & { data: string }>
+            let result = `<div>${tooltipColor('#333333')}${widthSpan(i18n.t('block.epoch'))} ${list[0].name}</div>`
+            list.forEach(data => {
+              result += parseTooltip(data)
+            })
+            return result
+          },
+        }
+      : undefined,
+    legend: !isThumbnail
+      ? {
+          data: [
+            {
+              name: i18n.t('block.epoch_time'),
+            },
+            {
+              name: i18n.t('block.epoch_length'),
+            },
+          ],
+          textStyle: {
+            fontSize: isMobile() ? 11 : 14,
+          },
+        }
+      : undefined,
+    grid: isThumbnail ? gridThumbnail : grid,
+    dataZoom: isThumbnail
+      ? []
+      : [
           {
-            name: i18n.t('block.difficulty'),
+            show: true,
+            realtime: true,
+            startValue,
+            endValue,
+            xAxisIndex: [0],
           },
           {
-            name: i18n.t('block.uncle_rate'),
-          },
-          {
-            name: i18n.t('block.epoch_time'),
-          },
-          {
-            name: i18n.t('block.epoch_length'),
+            type: 'inside',
+            realtime: true,
+            startValue,
+            endValue,
+            xAxisIndex: [0],
           },
         ],
-        textStyle: {
-          fontSize: isMobile() ? 11 : 14,
-        },
-      }
-    : undefined,
-  grid: isThumbnail ? gridThumbnail : grid,
-  dataZoom: isThumbnail ? [] : DATA_ZOOM_CONFIG,
-  xAxis: [
-    {
-      name: isMobile() || isThumbnail ? '' : i18n.t('block.epoch'),
-      nameLocation: 'middle',
-      nameGap: 30,
-      type: 'category',
-      boundaryGap: true,
-      data: statisticChartData.map(data => data.epochNumber),
-      axisLabel: {
-        formatter: (value: string) => value,
-      },
-    },
-  ],
-  yAxis: [
-    {
-      position: 'left',
-      name: isMobile() || isThumbnail ? '' : i18n.t('block.difficulty'),
-      type: 'value',
-      scale: true,
-      axisLine: {
-        lineStyle: {
-          color: chartColor.moreColors[0],
+
+    xAxis: [
+      {
+        name: isMobile() || isThumbnail ? '' : i18n.t('block.epoch'),
+        nameLocation: 'middle',
+        nameGap: 30,
+        type: 'category',
+        boundaryGap: true,
+        data: isThumbnail ? epochNumberSerie.slice(-1 * COUNT_IN_THUMBNAIL) : epochNumberSerie,
+        axisLabel: {
+          formatter: (value: string) => value,
         },
       },
-      axisLabel: {
-        formatter: (value: string) => handleAxis(new BigNumber(value)),
-      },
-    },
-    {
-      position: 'right',
-      name: isMobile() || isThumbnail ? '' : i18n.t('block.uncle_rate'),
-      type: 'value',
-      scale: true,
-      splitLine: {
-        show: false,
-      },
-      max: max(statisticChartData),
-      min: 0,
-      axisLine: {
-        lineStyle: {
-          color: chartColor.moreColors[1],
-        },
-      },
-      axisLabel: {
-        formatter: (value: string) => `${value}%`,
-      },
-    },
-    {
-      position: 'left',
-      scale: true,
-      axisLine: {
-        lineStyle: {
-          color: chartColor.moreColors[0],
-        },
-      },
-      axisLabel: {
-        formatter: () => '',
-      },
-    },
-    {
-      position: 'right',
-      scale: true,
-      axisLine: {
-        lineStyle: {
-          color: chartColor.moreColors[1],
-        },
-      },
-      axisLabel: {
-        formatter: () => '',
-      },
-    },
-  ],
-  series: [
-    {
-      name: i18n.t('block.difficulty'),
-      type: 'line',
-      step: 'start',
-      areaStyle: {
-        opacity: 0.3,
-        color: chartColor.moreColors[0],
-      },
-      yAxisIndex: 0,
-      symbol: isThumbnail ? 'none' : 'circle',
-      symbolSize: 5,
-      data: statisticChartData.map(data => new BigNumber(data.difficulty).toNumber()),
-    },
-    {
-      name: i18n.t('block.uncle_rate'),
-      type: 'line',
-      smooth: true,
-      yAxisIndex: 1,
-      symbol: 'circle',
-      symbolSize: 5,
-      data: statisticChartData.map(data => (Number(data.uncleRate) * 100).toFixed(2)),
-      markLine: isThumbnail
-        ? undefined
-        : {
-            symbol: 'none',
-            lineStyle: {
-              color: chartColor.moreColors[1],
-            },
-            data: [
-              {
-                name: i18n.t('block.uncle_rate_target'),
-                yAxis: 2.5,
-              },
-            ],
-            label: {
-              formatter: (params: any) => `${params.value}%`,
-            },
+    ],
+    yAxis: [
+      {
+        position: 'left',
+        name: isMobile() || isThumbnail ? '' : i18n.t('block.epoch_time'),
+        type: 'value',
+        scale: true,
+        axisLine: {
+          lineStyle: {
+            color: chartColor.moreColors[0],
           },
-    },
-    {
-      name: i18n.t('block.epoch_time'),
-      type: 'line',
-      step: 'start',
-      areaStyle: {
-        opacity: 0.3,
-        color: chartColor.moreColors[2],
+        },
+        axisLabel: {
+          formatter: (value: string) => handleAxis(new BigNumber(value)),
+        },
       },
-      yAxisIndex: 2,
-      symbol: isThumbnail ? 'none' : 'circle',
-      symbolSize: 5,
-      data: statisticChartData.map(data => parseHourFromMillisecond(data.epochTime)),
-    },
-    {
-      name: i18n.t('block.epoch_length'),
-      type: 'line',
-      step: 'start',
-      areaStyle: {
-        opacity: 0.3,
-        color: chartColor.moreColors[3],
+      {
+        position: 'right',
+        name: isMobile() || isThumbnail ? '' : i18n.t('block.epoch_length'),
+        type: 'value',
+        scale: true,
+        splitLine: {
+          show: false,
+        },
+        axisLine: {
+          lineStyle: {
+            color: chartColor.moreColors[1],
+          },
+        },
       },
-      yAxisIndex: 3,
-      symbol: isThumbnail ? 'none' : 'circle',
-      symbolSize: 5,
-      data: statisticChartData.map(data => data.epochLength),
-    },
-  ],
-})
+      {
+        position: 'left',
+        scale: true,
+        axisLine: {
+          lineStyle: {
+            color: chartColor.moreColors[0],
+          },
+        },
+        axisLabel: {
+          formatter: () => '',
+        },
+      },
+      {
+        position: 'right',
+        scale: true,
+        axisLine: {
+          lineStyle: {
+            color: chartColor.moreColors[1],
+          },
+        },
+        axisLabel: {
+          formatter: () => '',
+        },
+      },
+    ],
+    series: [
+      {
+        name: i18n.t('block.epoch_time'),
+        type: 'bar',
+        step: 'start',
+        yAxisIndex: 0,
+        symbol: isThumbnail ? 'none' : 'circle',
+        symbolSize: 5,
+        data: isThumbnail ? epochTimeSerie.slice(-1 * COUNT_IN_THUMBNAIL) : epochTimeSerie,
+      },
+      {
+        name: i18n.t('block.epoch_length'),
+        type: 'bar',
+        step: 'start',
+        yAxisIndex: 1,
+        symbol: isThumbnail ? 'none' : 'circle',
+        symbolSize: 5,
+        data: isThumbnail ? epochLengthSerie.slice(-1 * COUNT_IN_THUMBNAIL) : epochLengthSerie,
+      },
+    ],
+  }
+}
 
 export const DifficultyUncleRateEpochChart = ({ isThumbnail = false }: { isThumbnail?: boolean }) => {
   const { statisticDifficultyUncleRateEpochs, statisticDifficultyUncleRatesFetchEnd, app } = useAppState()
@@ -244,13 +201,7 @@ export const DifficultyUncleRateEpochChart = ({ isThumbnail = false }: { isThumb
 
 const toCSV = (statisticDifficultyUncleRateEpochs: State.StatisticDifficultyUncleRateEpoch[]) =>
   statisticDifficultyUncleRateEpochs
-    ? statisticDifficultyUncleRateEpochs.map(data => [
-        data.epochNumber,
-        data.difficulty,
-        data.uncleRate,
-        data.epochTime,
-        data.epochLength,
-      ])
+    ? statisticDifficultyUncleRateEpochs.map(data => [data.epochNumber, data.epochTime, data.epochLength])
     : []
 
 export default () => {
@@ -263,9 +214,7 @@ export default () => {
 
   return (
     <ChartPage
-      title={`${i18n.t('block.difficulty')} & ${i18n.t('block.uncle_rate')} & ${i18n.t('block.epoch_time')} & ${i18n.t(
-        'block.epoch_length',
-      )}`}
+      title={`${i18n.t('block.epoch_time')} & ${i18n.t('block.epoch_length')}`}
       data={toCSV(statisticDifficultyUncleRateEpochs)}
     >
       <DifficultyUncleRateEpochChart />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -120,7 +120,7 @@ const Containers: CustomRouter.Route[] = [
   },
   {
     name: 'DifficultyUncleRateEpochChart',
-    path: '/charts/difficulty-uncle-rate',
+    path: '/charts/epoch-time-length',
     exact: true,
     comp: DifficultyUncleRateEpochChart,
   },

--- a/src/service/app/charts/mining.ts
+++ b/src/service/app/charts/mining.ts
@@ -39,6 +39,7 @@ export const getStatisticDifficultyHashRate = (dispatch: AppDispatch) => {
       const difficultyHashRates = data.map(wrapper => ({
         epochNumber: wrapper.attributes.epochNumber,
         difficulty: wrapper.attributes.difficulty,
+        uncleRate: new BigNumber(wrapper.attributes.uncleRate).toFixed(4),
         hashRate: new BigNumber(wrapper.attributes.hashRate).multipliedBy(1000).toNumber(),
       }))
       dispatchDifficultyHashRate(dispatch, difficultyHashRates)
@@ -71,8 +72,6 @@ export const getStatisticDifficultyUncleRateEpoch = (dispatch: AppDispatch) => {
       const { data } = response
       const difficultyUncleRateEpochs = data.map(wrapper => ({
         epochNumber: wrapper.attributes.epochNumber,
-        difficulty: wrapper.attributes.difficulty,
-        uncleRate: new BigNumber(wrapper.attributes.uncleRate).toFixed(4),
         epochTime: wrapper.attributes.epochTime,
         epochLength: wrapper.attributes.epochLength,
       }))

--- a/src/service/http/fetcher.ts
+++ b/src/service/http/fetcher.ts
@@ -176,7 +176,7 @@ export const fetchStatisticCirculationRatio = () =>
   )
 
 export const fetchStatisticDifficultyHashRate = () =>
-  axiosIns(`/epoch_statistics/difficulty-hash_rate`).then((res: AxiosResponse) =>
+  axiosIns(`/epoch_statistics/difficulty-uncle_rate-hash_rate`).then((res: AxiosResponse) =>
     toCamelcase<Response.Response<Response.Wrapper<State.StatisticDifficultyHashRate>[]>>(res.data),
   )
 
@@ -206,7 +206,7 @@ export const fetchStatisticCellCount = () =>
   )
 
 export const fetchStatisticDifficultyUncleRateEpoch = () =>
-  axiosIns(`/epoch_statistics/difficulty-uncle_rate-epoch_time-epoch_length`).then((res: AxiosResponse) =>
+  axiosIns(`/epoch_statistics/epoch_time-epoch_length`).then((res: AxiosResponse) =>
     toCamelcase<Response.Response<Response.Wrapper<State.StatisticDifficultyUncleRateEpoch>[]>>(res.data),
   )
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -298,6 +298,7 @@ declare namespace State {
 
   export interface StatisticDifficultyHashRate {
     difficulty: string
+    uncleRate: string
     hashRate: string
     epochNumber: string
   }
@@ -325,8 +326,6 @@ declare namespace State {
   }
 
   export interface StatisticDifficultyUncleRateEpoch {
-    difficulty: string
-    uncleRate: string
     epochNumber: string
     epochTime: string
     epochLength: string
@@ -609,14 +608,14 @@ declare namespace State {
 
   export interface PagePayload
     extends PageState,
-    AddressState,
-    BlockState,
-    BlockListState,
-    TransactionState,
-    TransactionsState,
-    NervosDaoState,
-    UDTState,
-    TokensState { }
+      AddressState,
+      BlockState,
+      BlockListState,
+      TransactionState,
+      TransactionsState,
+      NervosDaoState,
+      UDTState,
+      TokensState {}
 
   export interface App {
     toast: ToastMessage | null


### PR DESCRIPTION
1. Move uncle rate from `Difficulty & Uncle Rate & Epoch Time & Epoch Length` to `Difficulty & Hash Rate`
![image](https://user-images.githubusercontent.com/7271329/180226036-be448613-e25b-4bc0-bca4-12441f70ef27.png)

2. adjust the style of difficulty & hash rate chart and epoch time & epoch length chart, and set initial scale of epoch time & epoch length to the last 1%
![image](https://user-images.githubusercontent.com/7271329/180226175-a9e126f7-a8fc-4131-acea-f74e7ffd84a0.png)
![image](https://user-images.githubusercontent.com/7271329/180226253-6ea75bc4-1754-44d3-ac0f-e5f2bd3786d1.png)
