### PR TITLE
fix: remove deprecated sudt script from script list

### DIFF
--- a/src/constants/scripts.ts
+++ b/src/constants/scripts.ts
@@ -195,14 +195,16 @@ export const TestnetContractHashTags: ContractHashTag[] = [
     category: 'type',
   },
   {
-    codeHashes: [
-      '0x48dbf59b4c7ee1547238021b4869bceedf4eea6b43772e5d66ef8865b6ae7212',
-      '0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4',
-    ],
-    txHashes: [
-      '0xc1b2ae129fad7465aaa9acc9785f842ba3e6e8b8051d899defa89f5508a77958-0',
-      '0xe12877ebd2c3c364dc46c5c992bcfaf4fee33fa13eebdf82c591fc9825aab769-0',
-    ],
+    codeHashes: ['0x48dbf59b4c7ee1547238021b4869bceedf4eea6b43772e5d66ef8865b6ae7212'],
+    txHashes: ['0xc1b2ae129fad7465aaa9acc9785f842ba3e6e8b8051d899defa89f5508a77958-0'],
+    depType: 'code',
+    hashType: 'data',
+    tag: 'sudt (deprecated)',
+    category: 'type',
+  },
+  {
+    codeHashes: ['0xc5e5dcf215925f7ef4dfaf5f4b4f105bc321c02776d6e7d52a1db3fcd9d011a4'],
+    txHashes: ['0xe12877ebd2c3c364dc46c5c992bcfaf4fee33fa13eebdf82c591fc9825aab769-0'],
     depType: 'code',
     hashType: 'type',
     tag: 'sudt',


### PR DESCRIPTION
This commit removes an incorrectly recorded sudt script from script list.

The first version of sudt script is of `hash type: data` but it was recorded as of `hash type: type`, which is incorrect.

Besides, the first version of sudt script was never committed into RFCs(there was a draft but closed), so it's not necessary to be listed.

Ref:
- draft PR mentioned the deprecated sudt script: https://github.com/nervosnetwork/rfcs/pull/199
- PR added the incorrect sudt info: https://github.com/nervosnetwork/ckb-explorer-frontend/commit/0b7e28514fb9697e95aeb25c3d221d605a2573be#diff-5636bb1b68c18c68892b6c62dfc3f46f9af26639e920bf49902e70156eedc2a1R156
- discord message: https://discord.com/channels/956765352514183188/959384192859389983/1021428076250407055