### PR TITLE
feat: add links to prev/next block on block page

### DIFF
--- a/src/assets/prev_block.svg
+++ b/src/assets/prev_block.svg
@@ -1,0 +1,5 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="20" height="20" rx="10" fill="#F0F0F0"/>
+<path d="M12.2339 4.79004L6.12519 9.81288L12.2339 14.8357" stroke="#999999" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -315,7 +315,9 @@
       "transactions_root": "Transactions Root",
       "pending": "Pending",
       "pending_tip": "The block reward of this block will be sent to the miner after 11 blocks，learn more from our Consensus Protocol",
-      "reward_sent_tip": "The reward of this block has been sent, click to check the details"
+      "reward_sent_tip": "The reward of this block has been sent, click to check the details",
+      "view_prev_block": "View the previous block",
+      "view_next_block": "View the next block"
     },
     "nervos_dao": {
       "nervos_dao": "Nervos DAO",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -315,7 +315,9 @@
       "witnesses_root": "Witnesses Root",
       "pending": "待发放",
       "pending_tip": "区块奖励将在 11 个区块后发送给矿工，阅读共识协议了解更多信息",
-      "reward_sent_tip": "区块奖励已经发送成功，请点击查看详情"
+      "reward_sent_tip": "区块奖励已经发送成功，请点击查看详情",
+      "view_prev_block": "查看上一区块",
+      "view_next_block": "查看下一区块"
     },
     "nervos_dao": {
       "nervos_dao": "Nervos DAO",

--- a/src/pages/BlockDetail/BlockComp.tsx
+++ b/src/pages/BlockDetail/BlockComp.tsx
@@ -28,11 +28,13 @@ import {
 import HelpIcon from '../../assets/qa_help.png'
 import MoreIcon from '../../assets/more.png'
 import MinerRewardIcon from '../../assets/miner_complete.png'
+import { ReactComponent as LeftArrow } from '../../assets/prev_block.svg'
 import { isMainnet } from '../../utils/chain'
 import DecimalCapacity from '../../components/DecimalCapacity'
 import CopyTooltipText from '../../components/Text/CopyTooltipText'
 import { DELAY_BLOCK_NUMBER } from '../../constants/common'
 import TitleCard from '../../components/Card/TitleCard'
+import styles from './styles.module.scss'
 
 const handleMinerText = (address: string) => {
   if (isMobile()) {
@@ -116,6 +118,7 @@ const BlockMinerReward = ({
 export const BlockOverview = () => {
   const {
     blockState: { block },
+    statistics: { tipBlockNumber },
   } = useAppState()
   const [showAllOverview, setShowAllOverview] = useState(false)
   const minerReward = <DecimalCapacity value={localeNumberString(shannonToCkb(block.minerReward))} />
@@ -129,7 +132,25 @@ export const BlockOverview = () => {
   let overviewItems: OverviewItemData[] = [
     {
       title: i18n.t('block.block_height'),
-      content: localeNumberString(block.number),
+      content: (
+        <div className={styles.blockNumber}>
+          <Tooltip placement="top" title={i18n.t('block.view_prev_block')}>
+            <Link to={`/block/${+block.number - 1}`} className={styles.prev} data-disabled={+block.number <= 0}>
+              <LeftArrow />
+            </Link>
+          </Tooltip>
+          {localeNumberString(block.number)}
+          <Tooltip title={i18n.t('block.view_next_block')}>
+            <Link
+              to={`/block/${+block.number + 1}`}
+              className={styles.next}
+              data-disabled={+block.number >= +tipBlockNumber}
+            >
+              <LeftArrow />
+            </Link>
+          </Tooltip>
+        </div>
+      ),
     },
     {
       title: i18n.t('block.miner'),

--- a/src/pages/BlockDetail/styles.module.scss
+++ b/src/pages/BlockDetail/styles.module.scss
@@ -1,0 +1,48 @@
+.blockNumber {
+  display: flex;
+  align-items: center;
+  .prev,
+  .next {
+    display: flex;
+    align-items: center;
+    svg {
+      rect {
+        fill: var(--primary-color);
+        opacity: 0.15;
+      }
+      path {
+        stroke: var(--primary-color);
+      }
+    }
+    &:hover {
+      svg {
+        rect {
+          fill: var(--primary-color);
+          opacity: 1;
+        }
+        path {
+          stroke: #fff;
+        }
+      }
+    }
+    &[data-disabled='true'] {
+      pointer-events: none;
+      svg {
+        rect {
+          fill: #f0f0f0;
+          opacity: 1;
+        }
+        path {
+          stroke: #999;
+        }
+      }
+    }
+  }
+  .prev {
+    margin-right: 8px;
+  }
+  .next {
+    margin-left: 8px;
+    transform: rotate(0.5turn);
+  }
+}


### PR DESCRIPTION
Add two links to the prev and next blocks, these two links are before and next to the block number on the page

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/71

Preview:
![image](https://user-images.githubusercontent.com/7271329/197489013-04780e1b-274b-44aa-b6fc-4dfe27b6d84e.png)
