### PR TITLE
feat: add capacity usage in cell info

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -68,6 +68,7 @@ export enum CellState {
   LOCK = 1,
   TYPE = 2,
   DATA = 3,
+  CAPACITY = 4,
 }
 
 export enum CellType {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -285,7 +285,10 @@
       "script_code_hash": "code_hash",
       "script_hash_type": "hash_type",
       "script_data": "data",
-      "export-transaction": "Export Transaction"
+      "export-transaction": "Export Transaction",
+      "capacity_usage": "Capacity Usage",
+      "declared_capacity": "declared",
+      "occupied_capacity": "occupied"
     },
     "block": {
       "block": "Block",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -284,7 +284,10 @@
       "script_code_hash": "code_hash",
       "script_hash_type": "hash_type",
       "script_data": "data",
-      "export-transaction": "导出交易"
+      "export-transaction": "导出交易",
+      "capacity_usage": "Capacity 使用情况",
+      "declared_capacity": "declared",
+      "occupied_capacity": "occupied"
     },
     "block": {
       "block": "区块",

--- a/src/pages/Transaction/TransactionCellScript/styled.tsx
+++ b/src/pages/Transaction/TransactionCellScript/styled.tsx
@@ -46,6 +46,13 @@ export const TransactionDetailData = styled(TransactionDetailItem)`
   }
 `
 
+export const TransactionDetailCapacityUsage = styled(TransactionDetailItem)`
+  margin-left: 90px;
+  @media (max-width: 750px) {
+    margin-left: 20px;
+  }
+`
+
 export const TransactionCellDetailPanel = styled.div`
   width: 100%;
   font-weight: 500;


### PR DESCRIPTION
This PR adds a `capacity usage` tab in the cell info dialog, the `usage` includes `declared capacity` and `occupied capacity`

1. declared capacity: `capacity` field of the cell
2. occupied capacity: size sum of `capacity` field, `lock` field, `type` field and `data` field

![image](https://user-images.githubusercontent.com/7271329/200165022-8cc918ca-135c-4ebb-b8ff-fe18f9ecb08e.png)
