### PR TITLE
fix: fix hex to utf8 method

### DIFF
--- a/src/__tests__/utils/string.test.ts
+++ b/src/__tests__/utils/string.test.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { TextDecoder } from 'util'
 import {
   parsePageNumber,
   startEndEllipsis,
@@ -41,10 +42,19 @@ describe('String methods tests', () => {
     )
   })
 
-  it('convert hex to utf8', async () => {
-    expect(hexToUtf8('0x68656c6c6f')).toBe('hello')
-    expect(hexToUtf8('0x6e6572766f73')).toBe('nervos')
-    expect(hexToUtf8('6e6572766f73')).toBe('nervos')
+  describe('Test hex to utf8', () => {
+    beforeAll(() => {
+      globalThis['TextDecoder'] = TextDecoder as any
+    })
+
+    afterAll(() => {
+      globalThis['TextDecoder'] = undefined as any
+    })
+
+    it('convert hex to utf8', async () => {
+      expect(hexToUtf8('0x68656c6c6f')).toBe('hello')
+      expect(hexToUtf8('0x6e6572766f73')).toBe('nervos')
+    })
   })
 
   it('search text correction', async () => {

--- a/src/pages/Transaction/TransactionCellScript/index.tsx
+++ b/src/pages/Transaction/TransactionCellScript/index.tsx
@@ -94,7 +94,7 @@ const handleFetchCellInfo = async (
         .then((wrapper: Response.Wrapper<State.Data> | null) => {
           const dataValue: State.Data = wrapper ? wrapper.attributes : initScriptContent.data
           if (wrapper && cell.isGenesisOutput) {
-            dataValue.data = hexToUtf8(wrapper.attributes.data.substr(2))
+            dataValue.data = hexToUtf8(wrapper.attributes.data)
           }
           return dataValue || initScriptContent.data
         })

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js'
+import { hexToBytes } from '@nervosnetwork/ckb-sdk-utils'
 
 export const parsePageNumber = (value: any, defaultValue: number) => {
   if (typeof value !== 'string') {
@@ -34,11 +35,9 @@ export const adaptPCEllipsis = (value: string, length = 8, factor = 40) => {
   return startEndEllipsis(value, length + step, length + step)
 }
 
-export const hexToUtf8 = (value: string) => {
-  if (!value) return value
-  const newValue = value.startsWith('0x') ? value.substring(2) : value
+export const hexToUtf8 = (value: string = '') => {
   try {
-    return decodeURIComponent(newValue.replace(/\s+/g, '').replace(/[0-9a-f]{2}/g, '%$&'))
+    return new TextDecoder().decode(hexToBytes(value))
   } catch (error) {
     return value
   }


### PR DESCRIPTION
This PR fixes the incorrect `hexToUtf8` method which cannot handle all utf8 characters before.

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/102#issuecomment-1306604902