### PR TITLE
Change env vars to secrets

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -9,7 +9,7 @@ jobs:
     uses: ./.github/workflows/_build_deploy.yml
     with:
       ckb-mode: mainnet
-      api-url: $MAINNET_API_URL
+      api-url: ${{ secrets.MAINNET_API_URL }}
       k8s-namespace: mainnet
       k8s-workload: ckb-explorer-front
     secrets: inherit

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,7 +9,7 @@ jobs:
     uses: ./.github/workflows/_build_deploy.yml
     with:
       ckb-mode: testnet
-      api-url: $STAGING_API_URL
+      api-url: ${{ secrets.STAGING_API_URL }}
       k8s-namespace: staging
       k8s-workload: ckb-explorer-front
     secrets: inherit

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -9,7 +9,7 @@ jobs:
     uses: ./.github/workflows/_build_deploy.yml
     with:
       ckb-mode: testnet
-      api-url: $TESTNET_API_URL
+      api-url: ${{secrets.TESTNET_API_URL}}
       k8s-namespace: testnet
       k8s-workload: ckb-explorer-front
     secrets: inherit


### PR DESCRIPTION
Because env vars are difficult to configure in Github, we unified these parameters to secrets.