### PR TITLE
Use environment secrets

### DIFF
--- a/.github/workflows/_build_deploy.yml
+++ b/.github/workflows/_build_deploy.yml
@@ -5,16 +5,19 @@ on:
       ckb-mode:
         required: true
         type: string
-      api-url:
-        required: true
-        type: string
       k8s-namespace:
         required: true
         type: string
       k8s-workload:
         required: true
         type: string
+      environment:
+        required: false
+        type: string
+        default: staging
     secrets:
+      # API_URL:
+      #   required: true
       GHCR_USERNAME:
         required: true
       GHCR_TOKEN:
@@ -28,12 +31,14 @@ on:
 jobs:                
   deploy:
     runs-on: ubuntu-latest
-
+    environment: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
+      # - uses: satackey/action-docker-layer-caching@v0.0.11
+      #   # Ignore the failure of a step and avoid terminating the job.
+      #   continue-on-error: true
       - name: Build and push
         id: docker_build
         uses: mr-smithers-excellent/docker-build-push@v5
@@ -41,7 +46,8 @@ jobs:
           image: ckb-explorer-frontend
           registry: ghcr.io
           githubOrg: magickbase # optional
-          buildArgs: "API_URL=${{ inputs.api-url }},CHAIN_TYPE=${{ inputs.ckb-mode }}"
+          buildArgs: "API_URL=${{ secrets.API_URL }},CHAIN_TYPE=${{ inputs.ckb-mode }}"
+          enableBuildKit: true
           username: ${{ secrets.GHCR_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Update image on K8S

--- a/.github/workflows/_build_deploy.yml
+++ b/.github/workflows/_build_deploy.yml
@@ -16,8 +16,6 @@ on:
         type: string
         default: staging
     secrets:
-      # API_URL:
-      #   required: true
       GHCR_USERNAME:
         required: true
       GHCR_TOKEN:
@@ -36,9 +34,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # - uses: satackey/action-docker-layer-caching@v0.0.11
-      #   # Ignore the failure of a step and avoid terminating the job.
-      #   continue-on-error: true
       - name: Build and push
         id: docker_build
         uses: mr-smithers-excellent/docker-build-push@v5

--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -12,6 +12,7 @@ jobs:
       api-url: $MAINNET_API_URL
       k8s-namespace: mainnet
       k8s-workload: ckb-explorer-front
+      environment: mainnet
     secrets: inherit
 
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,7 +9,7 @@ jobs:
     uses: ./.github/workflows/_build_deploy.yml
     with:
       ckb-mode: testnet
-      api-url: $STAGING_API_URL
       k8s-namespace: staging
       k8s-workload: ckb-explorer-front
+      environment: staging
     secrets: inherit

--- a/.github/workflows/testnet.yml
+++ b/.github/workflows/testnet.yml
@@ -12,5 +12,6 @@ jobs:
       api-url: $TESTNET_API_URL
       k8s-namespace: testnet
       k8s-workload: ckb-explorer-front
+      environment: testnet
     secrets: inherit
 


### PR DESCRIPTION
Fix the problem that incorrectly pass `API_URL` to building phase.

Setup 3 different deployment environment in Github:
- staging
- testnet
- mainnet

In these environments, all create a environment secret with the same name `API_URL` with corresponding API URL variable.
