### PR TITLE
ci: set node version in ci to 18.12.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12.22.8
+          node-version: 18.12.1
       - name: Install dependence
-        run: yarn install
+        run: yarn install --ignore-platform
       - name: Run a multi-line script
         run: |
           yarn build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.8-alpine as builder
+FROM node:18.12.1-alpine as builder
 
 ARG API_URL=https://testnet-api.explorer.nervos.org
 ARG CHAIN_TYPE=testnet


### PR DESCRIPTION
The specific version has been changed from 12 to 18 by #1145

1. update node version in github action
2. update node version in docker image