### PR TITLE
feat: add basic cycles field on block/transaction pages

### DIFF
--- a/src/components/Card/OverviewCard/index.tsx
+++ b/src/components/Card/OverviewCard/index.tsx
@@ -6,7 +6,7 @@ import { isScreenSmallerThan1200 } from '../../../utils/screen'
 import HelpIcon from '../../../assets/qa_help.png'
 import { useIsMobile } from '../../../utils/hook'
 
-export interface OverviewItemData {
+export type OverviewItemData = {
   title: ReactNode
   content: ReactNode
   contentWrapperClass?: string
@@ -15,40 +15,41 @@ export interface OverviewItemData {
   isAsset?: boolean
   tooltip?: string
   valueTooltip?: string
-}
+} | null
 
 const handleOverviewItems = (items: OverviewItemData[], isMobile: boolean) => ({
   leftItems: isMobile ? items : items.filter((_item: any, index: number) => index % 2 === 0),
   rightItems: isMobile ? [] : items.filter((_item: any, index: number) => index % 2 !== 0),
 })
 
-export const OverviewItem = ({ item, hideLine }: { item: OverviewItemData; hideLine: boolean }) => (
-  <OverviewItemPanel hideLine={hideLine} hasIcon={item.icon} isAsset={item.isAsset}>
-    <div className="overview_item__title__panel">
-      {item.icon && (
-        <div className="overview_item__icon">
-          <img src={item.icon} alt="item icon" />
+export const OverviewItem = ({ item, hideLine }: { item: OverviewItemData; hideLine: boolean }) =>
+  item ? (
+    <OverviewItemPanel hideLine={hideLine} hasIcon={item.icon} isAsset={item.isAsset}>
+      <div className="overview_item__title__panel">
+        {item.icon && (
+          <div className="overview_item__icon">
+            <img src={item.icon} alt="item icon" />
+          </div>
+        )}
+        <div className="overview_item__title">
+          <span>{item.title}</span>
+          {item.tooltip && (
+            <Tooltip placement="top" title={item.tooltip}>
+              <img src={HelpIcon} alt="help icon" />
+            </Tooltip>
+          )}
         </div>
-      )}
-      <div className="overview_item__title">
-        <span>{item.title}</span>
-        {item.tooltip && (
-          <Tooltip placement="top" title={item.tooltip}>
+      </div>
+      <div className={classNames('overview_item__value', { filled: item.filled }, item.contentWrapperClass)}>
+        {isValidElement(item.content) ? item.content : <span>{item.content}</span>}
+        {item.valueTooltip && (
+          <Tooltip placement="top" title={item.valueTooltip}>
             <img src={HelpIcon} alt="help icon" />
           </Tooltip>
         )}
       </div>
-    </div>
-    <div className={classNames('overview_item__value', { filled: item.filled }, item.contentWrapperClass)}>
-      {isValidElement(item.content) ? item.content : <span>{item.content}</span>}
-      {item.valueTooltip && (
-        <Tooltip placement="top" title={item.valueTooltip}>
-          <img src={HelpIcon} alt="help icon" />
-        </Tooltip>
-      )}
-    </div>
-  </OverviewItemPanel>
-)
+    </OverviewItemPanel>
+  ) : null
 
 export default ({
   items,
@@ -70,13 +71,15 @@ export default ({
       <div className="overview__separate" />
       <OverviewContentPanel length={leftItems.length}>
         <div className="overview_content__left_items">
-          {leftItems.map((item, index) => (
-            <OverviewItem
-              key={`${item.title?.toString()}-${item.content?.toString()}-${index}`}
-              item={item}
-              hideLine={index === leftItems.length - 1}
-            />
-          ))}
+          {leftItems.map((item, index) =>
+            item ? (
+              <OverviewItem
+                key={`${item.title?.toString()}-${item.content?.toString()}-${index}`}
+                item={item}
+                hideLine={index === leftItems.length - 1}
+              />
+            ) : null,
+          )}
         </div>
         {!isScreenSmallerThan1200() && <span />}
         <div className="overview_content__right_items">

--- a/src/contexts/states/block.ts
+++ b/src/contexts/states/block.ts
@@ -26,6 +26,7 @@ export const initBlockState: State.BlockState = {
     minerReward: '',
     liveCellChanges: '',
     size: 0,
+    cycles: null,
   },
   transactions: [],
   total: 0,

--- a/src/contexts/states/transaction.ts
+++ b/src/contexts/states/transaction.ts
@@ -18,6 +18,7 @@ export const initTransactionState: State.TransactionState = {
     txStatus: '',
     detailedMessage: '',
     bytes: 0,
+    cycles: null,
   },
   status: 'None',
   scriptFetched: false,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -293,6 +293,7 @@
       "occupied_capacity": "occupied",
       "size": "Size",
       "size_in_block": "{{bytes}} bytes in block",
+      "cycles": "Cycles",
       "since": {
         "relative": {
           "epoch": "After {{since}} epochs since committed",
@@ -336,7 +337,8 @@
       "reward_sent_tip": "The reward of this block has been sent, click to check the details",
       "view_prev_block": "View the previous block",
       "view_next_block": "View the next block",
-      "size": "Size"
+      "size": "Size",
+      "cycles": "Cycles"
     },
     "nervos_dao": {
       "nervos_dao": "Nervos DAO",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -292,6 +292,7 @@
       "occupied_capacity": "occupied",
       "size": "交易体积",
       "size_in_block": "区块中占 {{bytes}} bytes",
+      "cycles": "Cycles",
       "since": {
         "relative": {
           "epoch": "自 committed 之后 {{since}} Epochs",
@@ -336,7 +337,8 @@
       "reward_sent_tip": "区块奖励已经发送成功，请点击查看详情",
       "view_prev_block": "查看上一区块",
       "view_next_block": "查看下一区块",
-      "size": "区块体积"
+      "size": "区块体积",
+      "cycles": "Cycles"
     },
     "nervos_dao": {
       "nervos_dao": "Nervos DAO",

--- a/src/pages/BlockDetail/BlockComp.tsx
+++ b/src/pages/BlockDetail/BlockComp.tsx
@@ -149,24 +149,22 @@ export const BlockOverview = () => {
       content: <BlockMinerMessage minerMessage={block.minerMessage ?? i18n.t('common.none')} />,
     },
     {
+      title: i18n.t('block.size'),
+      content: block.size ? `${block.size.toLocaleString('en')} Bytes` : '-',
+    },
+    null,
+    {
+      title: i18n.t('block.cycles'),
+      content: block.cycles ? `${block.cycles.toLocaleString('en')} Bytes` : '-',
+    },
+    null,
+    {
       title: i18n.t('block.proposal_transactions'),
       content: block.proposalsCount ? localeNumberString(block.proposalsCount) : 0,
     },
     {
       title: i18n.t('block.epoch'),
       content: localeNumberString(block.epoch),
-    },
-    {
-      title: i18n.t('block.size'),
-      content: block.size ? `${block.size.toLocaleString('en')} Bytes` : '-',
-    },
-    {
-      title: i18n.t('block.epoch_start_number'),
-      content: (
-        <BlockLinkPanel>
-          <Link to={`/block/${block.startNumber}`}>{localeNumberString(block.startNumber)}</Link>
-        </BlockLinkPanel>
-      ),
     },
     {
       title: i18n.t('block.miner_reward'),
@@ -179,20 +177,28 @@ export const BlockOverview = () => {
       ),
     },
     {
-      title: i18n.t('block.block_index'),
-      content: `${Number(block.blockIndexInEpoch) + 1}/${block.length}`,
+      title: i18n.t('block.epoch_start_number'),
+      content: (
+        <BlockLinkPanel>
+          <Link to={`/block/${block.startNumber}`}>{localeNumberString(block.startNumber)}</Link>
+        </BlockLinkPanel>
+      ),
     },
     {
       title: i18n.t('block.difficulty'),
       content: handleDifficulty(block.difficulty),
     },
     {
-      title: i18n.t('block.timestamp'),
-      content: `${parseSimpleDate(block.timestamp)}`,
+      title: i18n.t('block.block_index'),
+      content: `${Number(block.blockIndexInEpoch) + 1}/${block.length}`,
     },
     {
       title: i18n.t('block.nonce'),
       content: <>{`0x${new BigNumber(block.nonce).toString(16)}`}</>,
+    },
+    {
+      title: i18n.t('block.timestamp'),
+      content: `${parseSimpleDate(block.timestamp)}`,
     },
     {
       title: i18n.t('block.uncle_count'),

--- a/src/pages/Transaction/TransactionComp.tsx
+++ b/src/pages/Transaction/TransactionComp.tsx
@@ -102,6 +102,7 @@ export const TransactionOverview = () => {
         txStatus,
         detailedMessage,
         bytes,
+        cycles,
       },
     },
     app: { tipBlockNumber },
@@ -112,7 +113,7 @@ export const TransactionOverview = () => {
     confirmation = tipBlockNumber - blockNumber
   }
 
-  const OverviewItems: OverviewItemData[] = [
+  const OverviewItems: Array<OverviewItemData> = [
     {
       title: i18n.t('block.block_height'),
       content: <TransactionBlockHeight blockNumber={blockNumber} txStatus={txStatus} />,
@@ -175,37 +176,44 @@ export const TransactionOverview = () => {
     )
   }
 
-  OverviewItems.push({
-    title: i18n.t('transaction.size'),
-    content: bytes ? (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-        }}
-      >
-        {`${(bytes - 4).toLocaleString('en')} Bytes`}
-        <Tooltip
-          placement="top"
-          title={i18n.t('transaction.size_in_block', {
-            bytes: bytes.toLocaleString('en'),
-          })}
+  OverviewItems.push(
+    {
+      title: i18n.t('transaction.size'),
+      content: bytes ? (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
         >
-          <img
-            src={MoreIcon}
-            alt="more"
-            style={{
-              width: 15,
-              height: 15,
-              marginLeft: 6,
-            }}
-          />
-        </Tooltip>
-      </div>
-    ) : (
-      ''
-    ),
-  })
+          {`${(bytes - 4).toLocaleString('en')} Bytes`}
+          <Tooltip
+            placement="top"
+            title={i18n.t('transaction.size_in_block', {
+              bytes: bytes.toLocaleString('en'),
+            })}
+          >
+            <img
+              src={MoreIcon}
+              alt="more"
+              style={{
+                width: 15,
+                height: 15,
+                marginLeft: 6,
+              }}
+            />
+          </Tooltip>
+        </div>
+      ) : (
+        ''
+      ),
+    },
+    null,
+    {
+      title: i18n.t('transaction.cycles'),
+      content: cycles ? `${cycles.toLocaleString('en')} Bytes` : '-',
+    },
+  )
 
   const TransactionParams = [
     {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -210,6 +210,7 @@ declare namespace State {
     minerReward: string
     liveCellChanges: string
     size: number
+    cycles: number | null
   }
 
   export interface CellDep {
@@ -239,6 +240,7 @@ declare namespace State {
     txStatus: string
     detailedMessage: string
     bytes: number
+    cycles: number | null
   }
 
   export interface BlockchainInfo {


### PR DESCRIPTION
This PR adds the basic `cycles` info on block/transaction pages.

Further details(max cycles in current epoch, max cycles on the chain) will be implemented later

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/87

---
![image](https://user-images.githubusercontent.com/7271329/212984559-7f2f319d-4daa-4799-999c-af7e6ba9dfe1.png)
![image](https://user-images.githubusercontent.com/7271329/212984622-371174e3-544d-4e34-835a-5e08b4187558.png)
