### PR TITLE
feat: improve ux from home page to list page

### DIFF
--- a/src/routes/state.ts
+++ b/src/routes/state.ts
@@ -1,3 +1,12 @@
+export interface RouteState$BlockListPage {
+  type: 'BlockListPage'
+  createTime: number
+  blocksDataWithFirstPage: {
+    blocks: State.Block[]
+    total: number
+  }
+}
+
 export interface RouteState$TransactionListPage {
   type: 'TransactionListPage'
   createTime: number
@@ -8,6 +17,7 @@ export interface RouteState$TransactionListPage {
 }
 
 export type RouteState =
+  | RouteState$BlockListPage
   | RouteState$TransactionListPage
   // Since the State property of the Location interface in `history/index.d.ts` is set to always exist,
   // but may actually be undefined, it is necessary here to actively provide a empty value to the generic

--- a/src/service/http/fetcher.ts
+++ b/src/service/http/fetcher.ts
@@ -22,10 +22,7 @@ export const v2AxiosIns = axios.create({
   data: null,
 })
 
-export const fetchBlocks = () =>
-  axiosIns.get('blocks').then((res: AxiosResponse) => toCamelcase<Response.Wrapper<State.Block>[]>(res.data.data))
-
-export const fetchBlockList = (page: number, size: number) =>
+export const fetchBlocks = (page: number, size: number) =>
   axiosIns
     .get('blocks', {
       params: {
@@ -34,6 +31,8 @@ export const fetchBlockList = (page: number, size: number) =>
       },
     })
     .then((res: AxiosResponse) => toCamelcase<Response.Response<Response.Wrapper<State.Block>[]>>(res.data))
+
+export const fetchLatestBlocks = (size: number) => fetchBlocks(1, size)
 
 export const fetchAddressInfo = (address: string) =>
   axiosIns
@@ -55,11 +54,6 @@ export const fetchTransactionByHash = (hash: string) =>
     .get(`transactions/${hash}`)
     .then((res: AxiosResponse) => toCamelcase<Response.Wrapper<State.Transaction>>(res.data.data))
 
-export const fetchLatestTransactions = () =>
-  axiosIns
-    .get('transactions')
-    .then((res: AxiosResponse) => toCamelcase<Response.Response<Response.Wrapper<State.Transaction>[]>>(res.data))
-
 export const fetchTransactions = (page: number, size: number) =>
   axiosIns
     .get('transactions', {
@@ -69,6 +63,8 @@ export const fetchTransactions = (page: number, size: number) =>
       },
     })
     .then((res: AxiosResponse) => toCamelcase<Response.Response<Response.Wrapper<State.Transaction>[]>>(res.data))
+
+export const fetchLatestTransactions = (size: number) => fetchTransactions(1, size)
 
 export const fetchPendingTransactions = (page: number, size: number) =>
   v2AxiosIns


### PR DESCRIPTION
Increases the number of requests from 15 to 25 when calling `fetchLatestBlocks` and `fetchLatestTransactions` in the home page, and provide page parameters to trigger the return of meta.

When jumping from the home page to the block list page, the data from the home page will be reused like the transaction list page.

PR based on #1178 .

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/164