### PR TITLE
fix: UI overlap in hash of Address page when going from mobile to non-mobile view

### DIFF
--- a/src/components/AddressText/index.tsx
+++ b/src/components/AddressText/index.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from 'antd'
-import { FC } from 'react'
+import { ComponentProps, FC } from 'react'
 import classNames from 'classnames'
 import { Link, LinkProps } from 'react-router-dom'
 import { useBoolean } from '../../utils/hook'
@@ -9,6 +9,7 @@ import styles from './styles.module.scss'
 
 const AddressText: FC<{
   children: string
+  fontKey?: ComponentProps<typeof EllipsisMiddle>['fontKey']
   className?: string
   containerClass?: string
   disableTooltip?: boolean
@@ -17,6 +18,7 @@ const AddressText: FC<{
   useTextWidthForPlaceholderWidth?: boolean
 }> = ({
   children: address,
+  fontKey,
   className,
   containerClass,
   disableTooltip,
@@ -34,6 +36,7 @@ const AddressText: FC<{
     >
       <EllipsisMiddle
         useTextWidthForPlaceholderWidth={useTextWidthForPlaceholderWidth}
+        fontKey={fontKey}
         className={classNames(
           {
             monospace,

--- a/src/components/Card/HashCard/index.tsx
+++ b/src/components/Card/HashCard/index.tsx
@@ -101,7 +101,9 @@ export default ({
               </LoadingPanel>
             ) : (
               <div id="hash__text">
-                <AddressText disableTooltip>{hash}</AddressText>
+                <AddressText disableTooltip fontKey={isMobile}>
+                  {hash}
+                </AddressText>
               </div>
             )}
             <SimpleButton

--- a/src/components/EllipsisMiddle/index.tsx
+++ b/src/components/EllipsisMiddle/index.tsx
@@ -7,6 +7,8 @@ const EllipsisMiddle: FC<
   HTMLAttributes<HTMLDivElement> & {
     children?: string
     text?: string
+    // Any key that represents the use of a different font
+    fontKey?: string | number | boolean
     minStartLen?: number
     minEndLen?: number
     onTruncateStateChange?: (isTruncated: boolean) => void
@@ -15,6 +17,7 @@ const EllipsisMiddle: FC<
 > = ({
   text,
   children,
+  fontKey,
   minStartLen = 0,
   minEndLen = 0,
   onTruncateStateChange,
@@ -85,7 +88,17 @@ const EllipsisMiddle: FC<
 
     setParts([leftPart.join(''), ellipsis, rightPart.join('')])
     onTruncateStateChange?.(true)
-  }, [children, minEndLen, minStartLen, onTruncateStateChange, ref, resizedWidth, text])
+  }, [
+    children,
+    // Active trigger recalculation
+    fontKey,
+    minEndLen,
+    minStartLen,
+    onTruncateStateChange,
+    ref,
+    resizedWidth,
+    text,
+  ])
 
   const { style, ...restDivProps } = divProps
   const combinedStyle = useMemo(


### PR DESCRIPTION
fix: UI overlap in hash of Address page when going from mobile to non-mobile view

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/172