### PR TITLE
fix: address page crashes when address is lockhash

### DIFF
--- a/src/pages/Address/AddressComp.tsx
+++ b/src/pages/Address/AddressComp.tsx
@@ -165,7 +165,7 @@ interface CoTAList {
 
 export const AddressAssetComp: FC<{ address: State.Address }> = ({ address }) => {
   const isLG = useIsLGScreen()
-  const { udtAccounts } = address
+  const { udtAccounts = [] } = address
 
   const { data: initList } = useQuery<AxiosResponse<CoTAList>>(
     ['cota-list', address.addressHash],

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -180,7 +180,7 @@ declare namespace State {
     minedBlocksCount: string
     isSpecial: boolean
     specialAddress: string
-    udtAccounts: Array<UDTAccount>
+    udtAccounts?: Array<UDTAccount>
   }
 
   export interface Block {


### PR DESCRIPTION
fix: address page crashes when address is lockhash

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/200