### PR TITLE
fix: fix clicking on address rank

### DIFF
--- a/src/pages/StatisticsChart/common/index.tsx
+++ b/src/pages/StatisticsChart/common/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, ReactElement, ReactNode, useMemo } from 'react'
+import { ComponentProps, ReactElement, ReactNode, useMemo, useEffect } from 'react'
 import 'echarts/lib/chart/line'
 import 'echarts/lib/chart/bar'
 import 'echarts/lib/chart/pie'
@@ -132,6 +132,7 @@ export function SmartChartPage<T>({
   isThumbnail = false,
   chartProps,
   fetchData,
+  onFetched,
   getEChartOption,
   toCSV,
   cacheKey,
@@ -159,6 +160,11 @@ export function SmartChartPage<T>({
 
   const query = useChartQueryWithCache(fetchData, cacheKey, cacheMode)
   const dataList = useMemo(() => query.data ?? [], [query.data])
+  useEffect(() => {
+    if (onFetched && query.data) {
+      onFetched(query.data)
+    }
+  }, [onFetched, query.data])
 
   const option = useMemo(
     () => getEChartOption(dataList, app.chartColor, isMobile, isThumbnail),


### PR DESCRIPTION
This PR fixes clicking on address rank by setting the rank data on fetching

The data set(https://github.com/nervosnetwork/ckb-explorer-frontend/blob/develop/src/pages/StatisticsChart/activities/AddressBalanceRank.tsx#L115-L117) used in onclick handler is expected to be data of the chart, but it's not updated by `onFetch` as expected because `onFetch` is not called when the data are fetched from cache or network

