### PR TITLE
fix: incorrect page navigation 404

### DIFF
--- a/src/pages/StatisticsChart/activities/AddressBalanceRank.tsx
+++ b/src/pages/StatisticsChart/activities/AddressBalanceRank.tsx
@@ -117,8 +117,11 @@ export const AddressBalanceRankChart = ({ isThumbnail = false }: { isThumbnail?:
   )
   const clickEvent = useCallback(
     (param: any) => {
-      if (param && param.name) {
-        history.push(`/address/${getAddressWithRanking(statisticAddressBalanceRanks, param.name)}`)
+      if (param && param.name && statisticAddressBalanceRanks.length > 0) {
+        const address = getAddressWithRanking(statisticAddressBalanceRanks, param.name)
+        if (address) {
+          history.push(`/address/${address}`)
+        }
       }
     },
     [statisticAddressBalanceRanks, history],


### PR DESCRIPTION
navigate back to `address-balance-rank` chart page, but 404 page is arrived at.
https://github.com/Magickbase/ckb-explorer-public-issues/issues/211