### PR TITLE
fix: divided `feeRates/confirmationTime` into a left open right close range

### DIFF
--- a/src/pages/FeeRateTracker/FeeRateTrackerComp.tsx
+++ b/src/pages/FeeRateTracker/FeeRateTrackerComp.tsx
@@ -102,7 +102,7 @@ export const ConfirmationTimeFeeRateChart = ({
     if (!cur.confirmationTime) {
       return acc
     }
-    const range = Math.floor((Math.ceil(cur.confirmationTime) - 1) / 10)
+    const range = Math.floor((cur.confirmationTime - 1) / 10)
     if (!Array.isArray(acc[range])) {
       acc[range] = []
     }

--- a/src/pages/FeeRateTracker/FeeRateTrackerComp.tsx
+++ b/src/pages/FeeRateTracker/FeeRateTrackerComp.tsx
@@ -102,7 +102,7 @@ export const ConfirmationTimeFeeRateChart = ({
     if (!cur.confirmationTime) {
       return acc
     }
-    const range = Math.round(cur.confirmationTime / 10)
+    const range = Math.floor((Math.ceil(cur.confirmationTime) - 1) / 10)
     if (!Array.isArray(acc[range])) {
       acc[range] = []
     }


### PR DESCRIPTION
It is a grouping issue of `feeRates/confirmationTime`

<img width="767" alt="image" src="https://user-images.githubusercontent.com/7877698/225300897-f7ffcc42-8a02-45f7-b8e9-49cb5a1c60ce.png">

I divided data into a left open right close range.
The label of x-axis and tooltip needs some suggestion? Is it necessary to show that's a left open right close range @Keith-CY 

<img width="286" alt="image" src="https://user-images.githubusercontent.com/7877698/225303150-3d40c105-b793-409d-a36f-eb18733c005b.png">
