### PR TITLE
fix: Label in `Total Nervos DAO Deposit` chart is overlapped

### DIFF
--- a/src/pages/StatisticsChart/nervosDao/TotalDaoDeposit.tsx
+++ b/src/pages/StatisticsChart/nervosDao/TotalDaoDeposit.tsx
@@ -9,7 +9,7 @@ import { tooltipColor, tooltipWidth, SeriesItem, SmartChartPage } from '../commo
 import { ChartCachedKeys } from '../../../constants/cache'
 import { fetchStatisticTotalDaoDeposit } from '../../../service/http/fetcher'
 
-const widthSpan = (value: string) => tooltipWidth(value, currentLanguage() === 'en' ? 110 : 110)
+const widthSpan = (value: string) => tooltipWidth(value, currentLanguage() === 'en' ? 168 : 110)
 
 const parseTooltip = ({ seriesName, data, color }: SeriesItem & { data: [string, string, string] }): string => {
   if (seriesName === i18n.t('statistic.total_dao_deposit')) {


### PR DESCRIPTION
<img width="424" alt="image" src="https://user-images.githubusercontent.com/7877698/226511644-f0c3edd2-b058-45ce-8e2c-c6a0ca1c0ed6.png">
<img width="451" alt="image" src="https://user-images.githubusercontent.com/7877698/226511741-30526070-ba95-4ba6-95f8-636127df50ab.png">
