### PR TITLE
feat: fallback banner to static image on mainnet

### DIFF
--- a/src/pages/Home/Banner/index.tsx
+++ b/src/pages/Home/Banner/index.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { BannerRender, createBannerRender } from './render'
 import styles from './index.module.scss'
 import { useIsMobile, usePrevious } from '../../../utils/hook'
+import { isMainnet as isMainnetFunc } from '../../../utils/chain'
 import BannerFallback from '../../../components/BannerFallback'
 
 // eslint-disable-next-line no-underscore-dangle
@@ -45,4 +46,11 @@ const _Banner: FC<{ latestBlock?: State.Block }> = ({ latestBlock }) => {
     </div>
   )
 }
-export const Banner = memo(_Banner, (a, b) => a.latestBlock?.number === b.latestBlock?.number)
+
+/*
+ * FIXME: this is a fallback for https://github.com/Magickbase/ckb-explorer-public-issues/issues/218 and should be restored once performance issue is fixed
+ */
+const isMainnet = isMainnetFunc()
+export const Banner = isMainnet
+  ? BannerFallback
+  : memo(_Banner, (a, b) => a.latestBlock?.number === b.latestBlock?.number)


### PR DESCRIPTION
Fallback banner to static image on mainnet due to performance issue of animated banner