### PR TITLE
fix: show `locktime` script tag in `multisig` script only when script args length is 28bytes

### DIFF
--- a/src/components/Script/index.tsx
+++ b/src/components/Script/index.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react'
 import { ScriptItemPanel, ScriptPanel } from './styled'
 import i18n from '../../utils/i18n'
 import HashTag from '../HashTag'
-import { matchScript } from '../../utils/util'
+import { getContractHashTag } from '../../utils/util'
 
 const ScriptItem = ({ title, children }: { title: string; children?: ReactNode }) => (
   <ScriptItemPanel>
@@ -14,7 +14,7 @@ const ScriptItem = ({ title, children }: { title: string; children?: ReactNode }
 )
 
 const Script = ({ script }: { script: State.Script }) => {
-  const contractHashTag = matchScript(script)
+  const contractHashTag = getContractHashTag(script)
   return (
     <ScriptPanel>
       <ScriptItem title={i18n.t('address.code_hash')}>

--- a/src/components/Script/index.tsx
+++ b/src/components/Script/index.tsx
@@ -14,7 +14,7 @@ const ScriptItem = ({ title, children }: { title: string; children?: ReactNode }
 )
 
 const Script = ({ script }: { script: State.Script }) => {
-  const contractHashTag = matchScript(script.codeHash, script.hashType)
+  const contractHashTag = matchScript(script)
   return (
     <ScriptPanel>
       <ScriptItem title={i18n.t('address.code_hash')}>

--- a/src/constants/scripts.ts
+++ b/src/constants/scripts.ts
@@ -21,7 +21,7 @@ export const MainnetContractHashTags: ContractHashTag[] = [
     txHashes: ['0x71a7ba8fc96349fea0ed3a5c47992e3b4084b031a42264a018e0072e8172e46c-1'],
     depType: 'dep_group',
     hashType: 'type',
-    tag: 'secp256k1 / multisig / locktime',
+    tag: 'secp256k1 / multisig',
     category: 'lock',
   },
   {
@@ -245,7 +245,7 @@ export const TestnetContractHashTags: ContractHashTag[] = [
     txHashes: ['0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37-1'],
     depType: 'dep_group',
     hashType: 'type',
-    tag: 'secp256k1 / multisig / locktime',
+    tag: 'secp256k1 / multisig',
     category: 'lock',
   },
   {

--- a/src/constants/scripts.ts
+++ b/src/constants/scripts.ts
@@ -7,6 +7,13 @@ export interface ContractHashTag {
   hashType: string
 }
 
+export const ScriptTagExtraRules = new Map<string, (s: State.Script) => string>([
+  [
+    'secp256k1 / multisig',
+    script => (script.args.length === 28 * 2 + 2 ? 'secp256k1 / multisig / locktime' : 'secp256k1 / multisig'),
+  ],
+])
+
 export const MainnetContractHashTags: ContractHashTag[] = [
   {
     codeHashes: ['0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8'],

--- a/src/pages/ScriptList/index.tsx
+++ b/src/pages/ScriptList/index.tsx
@@ -22,7 +22,7 @@ export const scripts = new Map<string, ScriptAttributes>([
     },
   ],
   [
-    'secp256k1 / multisig / locktime',
+    'secp256k1 / multisig',
     {
       name: 'SECP256K1/multisig',
       description: 'SECP256K1/multisig is a script which allows a group of users to sign a single transaction.',

--- a/src/pages/Transaction/TransactionCellScript/index.tsx
+++ b/src/pages/Transaction/TransactionCellScript/index.tsx
@@ -22,7 +22,7 @@ import { AppActions } from '../../../contexts/actions'
 import SmallLoading from '../../../components/Loading/SmallLoading'
 import { useDispatch } from '../../../contexts/providers'
 import CloseIcon from '../../../assets/modal_close.png'
-import { matchScript } from '../../../utils/util'
+import { getContractHashTag } from '../../../utils/util'
 import { localeNumberString } from '../../../utils/number'
 import HashTag from '../../../components/HashTag'
 import { ReactComponent as CopyIcon } from '../../../assets/copy_icon.svg'
@@ -188,7 +188,7 @@ const ScriptContent = ({
   content: State.Script | State.Data | CapacityUsage | undefined
   state: CellState
 }) => {
-  const hashTag = (content as State.Script).codeHash ? matchScript(content as State.Script) : undefined
+  const hashTag = getContractHashTag(content as State.Script)
   const data = content as State.Data
   const script = content as State.Script
 

--- a/src/pages/Transaction/TransactionCellScript/index.tsx
+++ b/src/pages/Transaction/TransactionCellScript/index.tsx
@@ -188,9 +188,7 @@ const ScriptContent = ({
   content: State.Script | State.Data | CapacityUsage | undefined
   state: CellState
 }) => {
-  const hashTag = (content as State.Script).codeHash
-    ? matchScript((content as State.Script).codeHash, (content as State.Script).hashType)
-    : undefined
+  const hashTag = (content as State.Script).codeHash ? matchScript(content as State.Script) : undefined
   const data = content as State.Data
   const script = content as State.Script
 


### PR DESCRIPTION
Issue: https://github.com/Magickbase/ckb-explorer-public-issues/issues/274