### PR TITLE
fix: fix default page size of transactions on the account page

### DIFF
--- a/src/__tests__/utils/string.test.ts
+++ b/src/__tests__/utils/string.test.ts
@@ -1,7 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { TextDecoder } from 'util'
 import {
-  parsePageNumber,
   startEndEllipsis,
   hexToUtf8,
   addPrefixForHash,
@@ -12,14 +11,6 @@ import {
 } from '../../utils/string'
 
 describe('String methods tests', () => {
-  it('parse valid number', async () => {
-    expect(parsePageNumber('a', 10)).toBe(10)
-    expect(parsePageNumber(2, 10)).toBe(10)
-    expect(parsePageNumber('2', 10)).toBe(2)
-    expect(parsePageNumber('0', 10)).toBe(10)
-    expect(parsePageNumber(undefined, 10)).toBe(10)
-  })
-
   it('start end ellipsis', async () => {
     expect(startEndEllipsis('0xckt1q9gry5zgmceslalm5xwn20v0krjpsugdnkkmkw5pqe5ge4')).toBe('0xckt1q9gry5zgmc...5pqe5ge4')
     expect(startEndEllipsis('0xckt1q9gry5zgmceslalm5xwn20v0krjpsugdnkkmkw5pqe5ge4', 16)).toBe(

--- a/src/pages/Address/index.tsx
+++ b/src/pages/Address/index.tsx
@@ -8,12 +8,12 @@ import { AddressTransactions, AddressOverview } from './AddressComp'
 import { fetchAddressInfo, fetchTransactionsByAddress } from '../../service/http/fetcher'
 import { QueryResult } from '../../components/QueryResult'
 import { defaultAddressInfo } from './state'
-import { usePaginationParamsInPage } from '../../utils/hook'
+import { usePaginationParamsInListPage } from '../../utils/hook'
 import { isAxiosError } from '../../utils/error'
 
 export const Address = () => {
   const { address } = useParams<{ address: string }>()
-  const { currentPage, pageSize } = usePaginationParamsInPage()
+  const { currentPage, pageSize } = usePaginationParamsInListPage()
 
   const addressInfoQuery = useQuery(['address_info', address], async () => {
     const wrapper = await fetchAddressInfo(address)

--- a/src/utils/hook.ts
+++ b/src/utils/hook.ts
@@ -13,7 +13,7 @@ import { useResizeDetector } from 'react-resize-detector'
 import { interval, share } from 'rxjs'
 import { AppCachedKeys } from '../constants/cache'
 import { deprecatedAddrToNewAddr } from './util'
-import { parsePageNumber, startEndEllipsis } from './string'
+import { startEndEllipsis } from './string'
 import { ListPageParams, PageParams } from '../constants/common'
 import {
   fetchCachedData,
@@ -214,8 +214,8 @@ export function usePaginationParamsFromSearch(opts: {
   const { defaultPage = 1, maxPage = Infinity, defaultPageSize = 10, maxPageSize = 100 } = opts
   const updateSearchParams = useUpdateSearchParams<'page' | 'size'>()
   const params = useSearchParams('page', 'size')
-  const currentPage = parsePageNumber(params.page, defaultPage)
-  const pageSize = parsePageNumber(params.size, defaultPageSize)
+  const currentPage = Number.isNaN(Number(params.page)) ? defaultPage : Number(params.page)
+  const pageSize = Number.isNaN(Number(params.size)) ? defaultPageSize : Number(params.size)
 
   useEffect(() => {
     const pageSizeOversized = pageSize > maxPageSize

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -2,13 +2,6 @@ import BigNumber from 'bignumber.js'
 import { hexToBytes } from '@nervosnetwork/ckb-sdk-utils'
 import { assert } from './error'
 
-export const parsePageNumber = (value: any, defaultValue: number) => {
-  if (typeof value !== 'string') {
-    return defaultValue
-  }
-  return parseInt(value, 10) || defaultValue
-}
-
 export function createTextMeasurer(element: HTMLElement): CanvasText['measureText'] {
   const style = window.getComputedStyle(element)
   const ctx = document.createElement('canvas').getContext('2d')


### PR DESCRIPTION
The default page sizes of transaction list on the account page are inconsistent in query and pagination component

`usePaginationParamsInPage` was used in the query while `usePaginationParamsInListPage` was used in the pagination component