### PR TITLE
refactor: use backend page size for pagination

### DIFF
--- a/src/pages/Address/AddressComp.tsx
+++ b/src/pages/Address/AddressComp.tsx
@@ -300,24 +300,19 @@ export const AddressOverview: FC<{ address: State.Address }> = ({ address }) => 
   )
 }
 
-type AddressTransactionsProps = {
-  address: string
-  transactions: State.Transaction[]
-  transactionsPageSize?: number
-  transactionsTotal: number
-  addressInfo: State.Address
-}
-
 export const AddressTransactions = ({
   address,
   transactions,
   transactionsTotal: total,
-  transactionsPageSize: realPageSize,
   addressInfo: { addressHash },
-}: AddressTransactionsProps) => {
+}: {
+  address: string
+  transactions: State.Transaction[]
+  transactionsTotal: number
+  addressInfo: State.Address
+}) => {
   const isMobile = useIsMobile()
-  const { currentPage, pageSize: defaultPageSize, setPage } = usePaginationParamsInListPage()
-  const pageSize = realPageSize ?? defaultPageSize
+  const { currentPage, pageSize, setPage } = usePaginationParamsInListPage()
   const searchParams = useSearchParams('layout')
   const defaultLayout = 'professional'
   const updateSearchParams = useUpdateSearchParams<'layout'>()

--- a/src/pages/Address/AddressComp.tsx
+++ b/src/pages/Address/AddressComp.tsx
@@ -300,19 +300,24 @@ export const AddressOverview: FC<{ address: State.Address }> = ({ address }) => 
   )
 }
 
+type AddressTransactionsProps = {
+  address: string
+  transactions: State.Transaction[]
+  transactionsPageSize?: number
+  transactionsTotal: number
+  addressInfo: State.Address
+}
+
 export const AddressTransactions = ({
   address,
   transactions,
   transactionsTotal: total,
+  transactionsPageSize: realPageSize,
   addressInfo: { addressHash },
-}: {
-  address: string
-  transactions: State.Transaction[]
-  transactionsTotal: number
-  addressInfo: State.Address
-}) => {
+}: AddressTransactionsProps) => {
   const isMobile = useIsMobile()
-  const { currentPage, pageSize, setPage } = usePaginationParamsInListPage()
+  const { currentPage, pageSize: defaultPageSize, setPage } = usePaginationParamsInListPage()
+  const pageSize = realPageSize ?? defaultPageSize
   const searchParams = useSearchParams('layout')
   const defaultLayout = 'professional'
   const updateSearchParams = useUpdateSearchParams<'layout'>()

--- a/src/pages/Address/index.tsx
+++ b/src/pages/Address/index.tsx
@@ -29,7 +29,8 @@ export const Address = () => {
       const { data, meta } = await fetchTransactionsByAddress(address, currentPage, pageSize)
       return {
         transactions: data.map(wrapper => wrapper.attributes),
-        total: meta ? meta.total : 0,
+        total: meta?.total ?? 0,
+        pageSize: meta?.pageSize,
       }
     } catch (err) {
       const isEmptyAddress = isAxiosError(err) && err.response?.status === 404
@@ -63,6 +64,7 @@ export const Address = () => {
               address={address}
               transactions={data.transactions}
               transactionsTotal={data.total}
+              transactionsPageSize={data.pageSize}
               addressInfo={addressInfoQuery.data ?? defaultAddressInfo}
             />
           )}

--- a/src/pages/Address/index.tsx
+++ b/src/pages/Address/index.tsx
@@ -29,8 +29,7 @@ export const Address = () => {
       const { data, meta } = await fetchTransactionsByAddress(address, currentPage, pageSize)
       return {
         transactions: data.map(wrapper => wrapper.attributes),
-        total: meta?.total ?? 0,
-        pageSize: meta?.pageSize,
+        total: meta ? meta.total : 0,
       }
     } catch (err) {
       const isEmptyAddress = isAxiosError(err) && err.response?.status === 404
@@ -64,7 +63,6 @@ export const Address = () => {
               address={address}
               transactions={data.transactions}
               transactionsTotal={data.total}
-              transactionsPageSize={data.pageSize}
               addressInfo={addressInfoQuery.data ?? defaultAddressInfo}
             />
           )}

--- a/src/pages/Address/index.tsx
+++ b/src/pages/Address/index.tsx
@@ -13,7 +13,7 @@ import { isAxiosError } from '../../utils/error'
 
 export const Address = () => {
   const { address } = useParams<{ address: string }>()
-  const { currentPage, pageSize } = usePaginationParamsInListPage()
+  const { currentPage, pageSize, watchServerPageSize } = usePaginationParamsInListPage()
 
   const addressInfoQuery = useQuery(['address_info', address], async () => {
     const wrapper = await fetchAddressInfo(address)
@@ -30,6 +30,7 @@ export const Address = () => {
       return {
         transactions: data.map(wrapper => wrapper.attributes),
         total: meta ? meta.total : 0,
+        pageSize: meta?.pageSize,
       }
     } catch (err) {
       const isEmptyAddress = isAxiosError(err) && err.response?.status === 404
@@ -42,6 +43,8 @@ export const Address = () => {
       throw err
     }
   })
+
+  watchServerPageSize(addressTransactionsQuery.data?.pageSize)
 
   return (
     <Content>

--- a/src/pages/BlockList/index.tsx
+++ b/src/pages/BlockList/index.tsx
@@ -153,7 +153,7 @@ export default () => {
     [t],
   )
 
-  const { currentPage, pageSize, setPage } = usePaginationParamsInListPage()
+  const { currentPage, pageSize, setPage, watchServerPageSize } = usePaginationParamsInListPage()
   const { state } = useLocation<RouteState>()
   const stateStaleTime = 3000
 
@@ -164,6 +164,7 @@ export default () => {
       return {
         blocks: data.map(wrapper => wrapper.attributes),
         total: meta?.total ?? 0,
+        pageSize: meta?.pageSize,
       }
     },
     {
@@ -181,6 +182,8 @@ export default () => {
     ...b,
     minerHash: deprecatedAddrToNewAddr(b.minerHash),
   }))
+
+  watchServerPageSize(query.data?.pageSize)
 
   return (
     <Content>

--- a/src/routes/state.ts
+++ b/src/routes/state.ts
@@ -4,6 +4,7 @@ export interface RouteState$BlockListPage {
   blocksDataWithFirstPage: {
     blocks: State.Block[]
     total: number
+    pageSize?: number
   }
 }
 

--- a/src/utils/hook.ts
+++ b/src/utils/hook.ts
@@ -250,11 +250,24 @@ export function usePaginationParamsFromSearch(opts: {
     [maxPageSize, updateSearchParams],
   )
 
+  const watchServerPageSize = useCallback(
+    (newPageSize?: number) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useEffect(() => {
+        if (newPageSize && newPageSize !== pageSize) {
+          setPageSize(newPageSize)
+        }
+      }, [newPageSize])
+    },
+    [pageSize, setPageSize],
+  )
+
   return {
     currentPage: Math.min(currentPage, maxPage),
     pageSize: Math.min(pageSize, maxPageSize),
     setPage,
     setPageSize,
+    watchServerPageSize,
   }
 }
 


### PR DESCRIPTION
![image](https://github.com/nervosnetwork/ckb-explorer-frontend/assets/20639676/f07101a5-2851-4b35-9b7e-8f5e7a9bb925)

This PR use the backend's page size for pagination in UI.

For more details, please see: https://github.com/Magickbase/ckb-explorer-public-issues/issues/356