### PR TITLE
chore: show maintenance info

### DIFF
--- a/src/components/Alert/index.tsx
+++ b/src/components/Alert/index.tsx
@@ -6,8 +6,8 @@ import { dayjs, parseSimpleDateNoSecond } from '../../utils/date'
 import SimpleButton from '../SimpleButton'
 import { ComponentActions } from '../../contexts/actions'
 import { AppCachedKeys } from '../../constants/cache'
+import { IS_MAINTAINING } from '../../constants/common'
 import styles from './styles.module.scss'
-import { isMainnet } from '../../utils/chain'
 
 const FIFTEEN_MINUTES = 15 * 60 * 1000
 
@@ -52,7 +52,7 @@ const Alert = () => {
     )
   }
 
-  if (!isMainnet()) {
+  if (IS_MAINTAINING) {
     return <div className={styles.container}>{i18n.t('error.maintain')}</div>
   }
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -14,6 +14,7 @@ export const EPOCH_HOURS = 4
 export const ONE_DAY_SECOND = 24 * 60 * 60
 export const ONE_HOUR_SECOND = 60 * 60
 export const ONE_MINUTE_SECOND = 60
+export const IS_MAINTAINING = process.env.REACT_APP_IS_MAINTAINING === 'true'
 
 export function getPrimaryColor() {
   return isMainnet() ? '#00CC9B' : '#9A2CEC'


### PR DESCRIPTION
This commit allows the maintenance info to be displayed by setting an environment variable "REACT_APP_IS_MAINTAINING=true" So Devops can toggle the maintenance status by restarting the service with different runtime env

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/397