### PR TITLE
fix: fix placeholder of search field on sudt detail page

### DIFF
--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -427,7 +427,7 @@
       "total_amount": "总量",
       "holder_addresses": "持币用户数",
       "decimal": "小数位",
-      "search_placeholder": "地址",
+      "search_placeholder": "交易/地址",
       "unknown_token": "未知资产",
       "submit_token_info": "提交代币信息",
       "unknown_token_description": "此代币信息暂时不完整，如果你是此代币的拥有者，请提交代币信息",


### PR DESCRIPTION
Placeholder should be "交易/地址" but not "地址"

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/421

Preview: https://ckb-explorer-frontend-in-magickbase-repo-git-e79f3c-magickbase.vercel.app/sudt/0x788c79191970e313693351531930b46a708b1ca58f6d414ddc8a8827afb554ff