### PR TITLE
fix: cannot call hooks in useMemo

### DIFF
--- a/src/pages/StatisticsChart/common/index.tsx
+++ b/src/pages/StatisticsChart/common/index.tsx
@@ -197,10 +197,7 @@ export function SmartChartPage<T>({
     }
   }, [onFetched, query.data])
 
-  const option = useMemo(
-    () => getEChartOption(dataList, ChartColor, isMobile, isThumbnail),
-    [dataList, getEChartOption, isMobile, isThumbnail],
-  )
+  const option = getEChartOption(dataList, ChartColor, isMobile, isThumbnail)
 
   const content = query.isLoading ? (
     <ChartLoading show isThumbnail={isThumbnail} />


### PR DESCRIPTION
According to the hook rule, we cannot call hooks in a primitive hook, such as `useMemo`, `useReducer`, or `useEffect`, and there are several [getEChartOption](https://github.com/nervosnetwork/ckb-explorer-frontend/blob/272c55939f7e5f295e87255806b89d34bba15172/src/pages/StatisticsChart/activities/AddressBalanceRank.tsx#L136)s are wrapped with `useCallback`