### PR TITLE
refactor(fiber): improve GraphNode transaction handling

### DIFF
--- a/src/__tests__/pages/Fiber/GraphNode/utils.test.ts
+++ b/src/__tests__/pages/Fiber/GraphNode/utils.test.ts
@@ -1,0 +1,139 @@
+import BigNumber from 'bignumber.js'
+import { calculateNodeMetrics } from '../../../../pages/Fiber/GraphNode/utils'
+import { formalizeChannelAsset } from '../../../../utils/fiber'
+
+// Mock the fiber utils
+jest.mock('../../../../utils/fiber', () => ({
+  formalizeChannelAsset: jest.fn(),
+}))
+
+describe('GraphNode Utils', () => {
+  const mockFormalizedAsset = {
+    funding: {
+      amount: '100',
+      symbol: 'CKB',
+    },
+    close: [
+      {
+        addr: 'address1',
+        amount: '50',
+        symbol: 'CKB',
+      },
+      {
+        addr: 'address2',
+        amount: '50',
+        symbol: 'CKB',
+      },
+    ],
+  }
+
+  beforeEach(() => {
+    ;(formalizeChannelAsset as jest.Mock).mockReturnValue(mockFormalizedAsset)
+  })
+
+  describe('calculateNodeMetrics', () => {
+    const mockChannel = {
+      openTransactionInfo: {
+        txHash: 'open-tx-hash',
+        blockNumber: 1000,
+        blockTimestamp: 1600000000,
+        address: 'funding-address',
+        udtInfo: {
+          typeHash: 'udt-type-hash',
+          iconFile: 'icon.png',
+        },
+      },
+    }
+
+    const mockClosedChannel = {
+      ...mockChannel,
+      closedTransactionInfo: {
+        txHash: 'close-tx-hash',
+        blockNumber: 1100,
+        blockTimestamp: 1600001000,
+      },
+    }
+
+    const mockNode = {
+      fiberGraphChannels: [mockChannel, mockClosedChannel],
+    }
+
+    it('should separate open and closed channels', () => {
+      const result = calculateNodeMetrics(mockNode as any)
+
+      expect(result.openChannels).toHaveLength(1)
+      expect(result.closedChannels).toHaveLength(1)
+      expect(result.openChannels[0]).toEqual(mockChannel)
+      expect(result.closedChannels[0]).toEqual(mockClosedChannel)
+    })
+
+    it('should generate transactions for channel operations', () => {
+      const result = calculateNodeMetrics(mockNode as any)
+
+      expect(result.transactions).toHaveLength(3) // 2 opens + 1 close
+
+      // Check transaction order (most recent first)
+      expect(result.transactions[0].hash).toBe('close-tx-hash')
+      expect(result.transactions[0].isOpen).toBe(false)
+
+      // Check transaction details
+      const openTx = result.transactions[1]
+      expect(openTx).toMatchObject({
+        hash: 'open-tx-hash',
+        isOpen: true,
+        isUdt: true,
+        block: {
+          number: 1000,
+          timestamp: 1600000000,
+        },
+        accounts: [
+          {
+            address: 'funding-address',
+            amount: '100 CKB',
+          },
+        ],
+      })
+    })
+
+    it('should calculate total liquidity from open channels', () => {
+      const result = calculateNodeMetrics(mockNode as any)
+
+      const liquidity = result.totalLiquidity.get('udt-type-hash')
+      expect(liquidity).toBeDefined()
+      expect(liquidity?.symbol).toBe('CKB')
+      expect(liquidity?.iconFile).toBe('icon.png')
+      expect(liquidity?.amount).toEqual(new BigNumber(100))
+    })
+
+    it('should handle empty node with no channels', () => {
+      const emptyNode = { fiberGraphChannels: [] }
+      const result = calculateNodeMetrics(emptyNode as any)
+
+      expect(result.openChannels).toHaveLength(0)
+      expect(result.closedChannels).toHaveLength(0)
+      expect(result.transactions).toHaveLength(0)
+      expect(result.totalLiquidity.size).toBe(0)
+    })
+
+    it('should handle channels without UDT info', () => {
+      const nonUdtChannel = {
+        openTransactionInfo: {
+          txHash: 'tx-hash',
+          blockNumber: 1000,
+          blockTimestamp: 1600000000,
+          address: 'address',
+        },
+      }
+
+      const node = {
+        fiberGraphChannels: [nonUdtChannel],
+      }
+
+      const result = calculateNodeMetrics(node as any)
+
+      expect(result.transactions[0].isUdt).toBe(false)
+      const liquidity = result.totalLiquidity.get('ckb')
+      expect(liquidity).toBeDefined()
+    })
+  })
+})

--- a/src/pages/Fiber/GraphNode/LiquidityChart/index.tsx
+++ b/src/pages/Fiber/GraphNode/LiquidityChart/index.tsx
@@ -1,28 +1,22 @@
 import type { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { EChartOption } from 'echarts'
+import type { EChartOption } from 'echarts'
 import { SmartChartPage } from '../../../StatisticsChart/common'
 import { variantColors } from '../../../../utils/chart'
+import type { AssetRecord } from '../types'
 
-interface AssetRecord {
-  symbol: string
-  usd: string
-}
-
-const useOption = (list: AssetRecord[]): echarts.EChartOption => {
+const useChartOption = (list: AssetRecord[]): EChartOption => {
   const { t } = useTranslation()
-
-  const tooltip: EChartOption.Tooltip = {
-    formatter: data => {
-      const item = Array.isArray(data) ? data[0] : data
-      return `${item.name}: ${item.value} USD (${item.percent}%)`
-    },
-  }
-
   const colors = variantColors(list.length)
+
   return {
     color: colors,
-    tooltip,
+    tooltip: {
+      formatter: data => {
+        const item = Array.isArray(data) ? data[0] : data
+        return `${item.name}: ${item.value} USD (${item.percent}%)`
+      },
+    },
     grid: {
       left: '4%',
       right: '10%',
@@ -45,12 +39,10 @@ const useOption = (list: AssetRecord[]): echarts.EChartOption => {
             shadowColor: 'rgba(0, 0, 0, 0.5)',
           },
         },
-        data: list.map(data => {
-          return {
-            name: data.symbol,
-            value: data.usd,
-          }
-        }),
+        data: list.map(data => ({
+          name: data.symbol,
+          value: data.usd,
+        })),
       },
     ],
   }
@@ -58,7 +50,6 @@ const useOption = (list: AssetRecord[]): echarts.EChartOption => {
 
 export const LiquidityChart: FC<{ assets: AssetRecord[] }> = ({ assets }) => {
   const [t] = useTranslation()
-
   const data = assets.filter(a => +a.usd > 0)
 
   if (!data.length) return null
@@ -68,8 +59,8 @@ export const LiquidityChart: FC<{ assets: AssetRecord[] }> = ({ assets }) => {
       title={t('fiber.graph.node.liquidity_allocation')}
       isThumbnail
       fetchData={() => Promise.resolve(data)}
-      getEChartOption={useOption}
-      queryKey={`${Math.random()}`}
+      getEChartOption={useChartOption}
+      queryKey={`liquidity-chart-${data.map(d => d.usd).join('-')}`}
     />
   )
 }

--- a/src/pages/Fiber/GraphNode/types.ts
+++ b/src/pages/Fiber/GraphNode/types.ts
@@ -1,0 +1,36 @@
+import type { BigNumber } from 'bignumber.js'
+import { Fiber } from '../../../services/ExplorerService/fetcher'
+
+export interface AssetRecord {
+  symbol: string
+  usd: string
+}
+
+export interface NodeTransaction {
+  hash: string
+  index?: string
+  block: {
+    number: number
+    timestamp: number
+  }
+  isUdt: boolean
+  isOpen: boolean
+  accounts: {
+    amount: string
+    address: string
+  }[]
+}
+
+export interface NodeLiquidity {
+  amount: BigNumber
+  symbol: string
+  iconFile?: string
+  usd?: BigNumber
+}
+
+export interface NodeMetrics {
+  transactions: NodeTransaction[]
+  openChannels: Fiber.Graph.Channel[]
+  closedChannels: Fiber.Graph.Channel[]
+  totalLiquidity: Map<string, NodeLiquidity>
+}

--- a/src/pages/Fiber/GraphNode/utils.ts
+++ b/src/pages/Fiber/GraphNode/utils.ts
@@ -1,0 +1,114 @@
+import BigNumber from 'bignumber.js'
+import { Fiber } from '../../../services/ExplorerService/fetcher'
+import { formalizeChannelAsset } from '../../../utils/fiber'
+import type { NodeMetrics, NodeTransaction } from './types'
+
+interface FiberGraphNode extends Fiber.Graph.Node {
+  fiberGraphChannels: (Fiber.Graph.Channel & {
+    closedTransactionInfo?: {
+      txHash: string
+      blockNumber: number
+      blockTimestamp: number
+    }
+    openTransactionInfo: {
+      txHash: string
+      blockNumber: number
+      blockTimestamp: number
+      address: string
+      udtInfo?: {
+        typeHash: string
+        iconFile?: string
+      }
+    }
+  })[]
+}
+
+/**
+ * Calculates metrics for a Fiber Graph Node including:
+ * - Open and closed channels
+ * - Transaction history for channel operations
+ * - Total liquidity across all open channels
+ *
+ * @param node - The Fiber Graph Node to analyze
+ * @returns NodeMetrics containing channel states, transactions and liquidity info
+ */
+export const calculateNodeMetrics = (node: FiberGraphNode): NodeMetrics => {
+  const [openChannels, closedChannels] = node.fiberGraphChannels.reduce<[Fiber.Graph.Channel[], Fiber.Graph.Channel[]]>(
+    (acc: [Fiber.Graph.Channel[], Fiber.Graph.Channel[]], channel: Fiber.Graph.Channel) => {
+      if (channel.closedTransactionInfo?.txHash) {
+        acc[1].push(channel)
+      } else {
+        acc[0].push(channel)
+      }
+      return acc
+    },
+    [[], []],
+  )
+
+  const transactions = node.fiberGraphChannels.reduce<NodeTransaction[]>(
+    (acc: NodeTransaction[], channel: Fiber.Graph.Channel) => {
+      const assets = formalizeChannelAsset(channel)
+
+      // Add open transaction
+      acc.push({
+        hash: channel.openTransactionInfo.txHash,
+        isOpen: true,
+        isUdt: !!channel.openTransactionInfo.udtInfo,
+        block: {
+          number: channel.openTransactionInfo.blockNumber,
+          timestamp: channel.openTransactionInfo.blockTimestamp,
+        },
+        accounts: [
+          {
+            address: channel.openTransactionInfo.address,
+            amount: `${assets.funding.amount} ${assets.funding.symbol}`,
+          },
+        ],
+      })
+
+      // Add close transaction if exists
+      if (channel.closedTransactionInfo?.txHash) {
+        acc.push({
+          hash: channel.closedTransactionInfo.txHash,
+          isOpen: false,
+          isUdt: !!channel.openTransactionInfo.udtInfo,
+          block: {
+            number: channel.closedTransactionInfo.blockNumber,
+            timestamp: channel.closedTransactionInfo.blockTimestamp,
+          },
+          accounts:
+            assets.close?.map(a => ({
+              address: a.addr,
+              amount: `${a.amount} ${a.symbol}`,
+            })) ?? [],
+        })
+      }
+
+      return acc
+    },
+    [],
+  )
+
+  // Calculate total liquidity
+  const totalLiquidity = new Map()
+  openChannels.forEach((channel: Fiber.Graph.Channel) => {
+    const assets = formalizeChannelAsset(channel)
+    const key = channel.openTransactionInfo.udtInfo?.typeHash ?? 'ckb'
+
+    const current = totalLiquidity.get(key) ?? {
+      amount: new BigNumber(0),
+      symbol: assets.funding.symbol,
+      iconFile: channel.openTransactionInfo.udtInfo?.iconFile,
+    }
+
+    current.amount = current.amount.plus(new BigNumber(assets.funding.amount ?? 0))
+    totalLiquidity.set(key, current)
+  })
+
+  return {
+    transactions: transactions.sort((a: NodeTransaction, b: NodeTransaction) => b.block.timestamp - a.block.timestamp),
+    openChannels,
+    closedChannels,
+    totalLiquidity,
+  }
+}


### PR DESCRIPTION
This PR is generated by Claude and reviewed by @Keith-CY

This pull request includes several changes to improve the functionality and readability of the `GraphNode` component and its associated utilities and tests. The most important changes include adding new tests for `calculateNodeMetrics`, refactoring the `LiquidityChart` component, and improving the `GraphNode` component's logic and structure.

### Improvements to testing:

* [`src/__tests__/pages/Fiber/GraphNode/utils.test.ts`](diffhunk://#diff-0ceeb022719ec010d974859c6ab7843fa1275fb9b7cb727fc92c52b7831558d5R1-R139): Added new tests for the `calculateNodeMetrics` function, including tests for separating open and closed channels, generating transactions, calculating total liquidity, handling empty nodes, and channels without UDT info.

### Refactoring components:

* [`src/pages/Fiber/GraphNode/LiquidityChart/index.tsx`](diffhunk://#diff-0ffe5fb39a33cbbceec14967061afbe868623dfc78f70a65ddc2b594beb7dffbL3-R19): Refactored the `LiquidityChart` component to improve type usage and renamed the `useOption` function to `useChartOption`. Also, updated the `getEChartOption` prop to use the new function name and improved the query key generation. [[1]](diffhunk://#diff-0ffe5fb39a33cbbceec14967061afbe868623dfc78f70a65ddc2b594beb7dffbL3-R19) [[2]](diffhunk://#diff-0ffe5fb39a33cbbceec14967061afbe868623dfc78f70a65ddc2b594beb7dffbL48-L61) [[3]](diffhunk://#diff-0ffe5fb39a33cbbceec14967061afbe868623dfc78f70a65ddc2b594beb7dffbL71-R63)

### Enhancements to `GraphNode` component:

* [`src/pages/Fiber/GraphNode/index.tsx`](diffhunk://#diff-e7b0f462cf3930e38584950285bcc433db19c59f8f8154860173bae7cffcea1aR27-R38): Refactored the `GraphNode` component to improve state management, memoization, and readability. This includes simplifying the logic for handling addresses, transactions, and liquidity calculations. Added utility functions for rendering transactions and generating transaction keys, links, and tooltips. [[1]](diffhunk://#diff-e7b0f462cf3930e38584950285bcc433db19c59f8f8154860173bae7cffcea1aR27-R38) [[2]](diffhunk://#diff-e7b0f462cf3930e38584950285bcc433db19c59f8f8154860173bae7cffcea1aL52-R65) [[3]](diffhunk://#diff-e7b0f462cf3930e38584950285bcc433db19c59f8f8154860173bae7cffcea1aL103-R83) [[4]](diffhunk://#diff-e7b0f462cf3930e38584950285bcc433db19c59f8f8154860173bae7cffcea1aR96-R247) [[5]](diffhunk://#diff-e7b0f462cf3930e38584950285bcc433db19c59f8f8154860173bae7cffcea1aL231-R266) [[6]](diffhunk://#diff-e7b0f462cf3930e38584950285bcc433db19c59f8f8154860173bae7cffcea1aL252-R293) [[7]](diffhunk://#diff-e7b0f462cf3930e38584950285bcc433db19c59f8f8154860173bae7cffcea1aL283-R315)