### PR TITLE
refactor: refactor btc address validation and add tests

### DIFF
--- a/src/__tests__/utils/bitcoin.test.ts
+++ b/src/__tests__/utils/bitcoin.test.ts
@@ -1,0 +1,30 @@
+import { isValidBTCAddress } from '../../utils/bitcoin'
+
+describe('Bitcoin Utility Functions', () => {
+  describe('isValidBTCAddress', () => {
+    it('should return true for valid Bitcoin addresses', () => {
+      const validAddresses = [
+        'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn', // P2PKH
+        '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc', // P2SH
+        'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx', // P2WPKH
+        'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7', // P2WSH
+        'tb1p9lw5w4mcv5a2uvx9gkkhcnvcajza5zvh27yatmagffv2jdwk43aqnw647e', // P2TR
+      ]
+      validAddresses.forEach(address => {
+        expect(isValidBTCAddress(address)).toBe(true)
+      })
+    })
+
+    it('should return false for invalid Bitcoin addresses', () => {
+      const invalidAddresses = [
+        'invalidAddress123',
+        't1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfN', // Too short
+        't3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLz', // Invalid checksum
+        'tb1qw508d6qejxtdg4y5r3z5j6q2j0g0g0g0g0g0g0g0', // Invalid Bech32 address
+      ]
+      invalidAddresses.forEach(address => {
+        expect(isValidBTCAddress(address)).toBe(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This commit is generated by claude and reviewed by @Keith-CY

This pull request includes several changes to the Bitcoin utility functions and their tests. The most important changes involve adding tests for the `isValidBTCAddress` function and improving the `fromBech32` and `parseBTCAddress` functions to handle different Bitcoin address types and errors more effectively.

### Tests for Bitcoin Utility Functions:
* Added tests for `isValidBTCAddress` to check for both valid and invalid Bitcoin addresses in `src/__tests__/utils/bitcoin.test.ts`.

### Improvements to `fromBech32` function:
* Enhanced error handling in `fromBech32` by adding specific error messages for invalid Bech32 and Bech32m addresses and ensuring the correct data length is handled.

### Improvements to `parseBTCAddress` function:
* Refactored `parseBTCAddress` to try Base58 decoding first and then Bech32 decoding, with improved error handling and support for future SegWit addresses. [[1]](diffhunk://#diff-61402c944e589f6a79fe87e442efc15b58919354602b4647314eafb15d4e2603L93-R127) [[2]](diffhunk://#diff-61402c944e589f6a79fe87e442efc15b58919354602b4647314eafb15d4e2603L169-R148)

These changes improve the robustness and reliability of the Bitcoin address parsing and validation functions.