### PR TITLE
ci: exclude checking typos in tests

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -8,3 +8,6 @@ th='th'
 toekn='toekn'
 # echart config
 metalness = 'metalness'
+
+[files]
+extend-exclude=["*.test.*"]


### PR DESCRIPTION
because several hashes are included in tests