### PR TITLE
refactor: use spore sdk to fetch spore image

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,13 @@
 const { TextEncoder, TextDecoder } = require('util')
 global.TextEncoder = TextEncoder
 global.TextDecoder = TextDecoder
+
+// Mock @nervina-labs/dob-render
+jest.mock('@nervina-labs/dob-render', () => ({
+  config: {
+    setDobDecodeServerURL: jest.fn(),
+    setQueryBtcFsFn: jest.fn(),
+  },
+  renderByTokenKey: jest.fn(),
+  svgToBase64: jest.fn()
+}))

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@ckb-lumos/molecule": "0.23.0",
     "@ckb-lumos/rpc": "0.23.0",
     "@microlink/react-json-view": "1.23.0",
+    "@nervina-labs/dob-render": "^0.2.3",
     "@nervosnetwork/ckb-sdk-rpc": "0.109.1",
     "@nervosnetwork/ckb-sdk-utils": "0.109.1",
     "@radix-ui/react-icons": "1.3.0",
@@ -138,10 +139,14 @@
   "jest": {
     "displayName": "Unit Test",
     "moduleNameMapper": {
-      "axios": "axios/dist/node/axios.cjs"
+      "axios": "axios/dist/node/axios.cjs",
+      "@nervina-labs/dob-render": "<rootDir>/node_modules/@nervina-labs/dob-render/dist/index.js"
     },
     "setupFilesAfterEnv": [
       "<rootDir>/jest.setup.js"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@nervina-labs/dob-render)/)"
     ]
   },
   "eslintConfig": {

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -173,3 +173,5 @@ export const NERVOS_DAO_RFC_URL =
   'https://www.github.com/nervosnetwork/rfcs/blob/master/rfcs/0023-dao-deposit-withdraw/0023-dao-deposit-withdraw.md'
 
 export const TIME_TEMPLATE = 'YYYY-MM-DD HH:mm:ss'
+
+export const DEFAULT_SPORE_IMAGE = '/images/spore_placeholder.svg'

--- a/src/models/Address/UDTAccount.ts
+++ b/src/models/Address/UDTAccount.ts
@@ -1,3 +1,5 @@
+import { Script } from '../Script'
+
 export interface XUDT {
   symbol: string
   decimal: string
@@ -54,6 +56,7 @@ export interface Spore {
   collection: {
     typeHash: string | null
   }
+  udtTypeScript: Script
 }
 
 export interface OmigaInscription {

--- a/src/pages/NftCollectionInfo/ItemCover/index.tsx
+++ b/src/pages/NftCollectionInfo/ItemCover/index.tsx
@@ -1,0 +1,56 @@
+import { type FC } from 'react'
+
+import { useQuery } from '@tanstack/react-query'
+import { type NFTCollection, type NFTItem } from '../../../services/ExplorerService'
+import { ReactComponent as CoverIcon } from '../../../assets/nft_cover.svg'
+import { handleNftImgError, patchMibaoImg } from '../../../utils/util'
+import { getSporeImg } from '../../../utils/spore'
+import { DEFAULT_SPORE_IMAGE } from '../../../constants/common'
+import styles from './styles.module.scss'
+
+const Cover: FC<{ item: NFTItem; info?: NFTCollection; size?: 'lg' | 'md' | 'sm' }> = ({ item, info, size = 'lg' }) => {
+  const dobRenderParams =
+    item?.standard === 'spore' && item.cell?.data
+      ? {
+          data: item.cell.data,
+          id: item.type_script.args,
+        }
+      : null
+
+  const { data: dobImg, isLoading } = useQuery({
+    queryKey: ['dob_render_img', dobRenderParams],
+    queryFn: () => (dobRenderParams ? getSporeImg(dobRenderParams) : DEFAULT_SPORE_IMAGE),
+    enabled: !!dobRenderParams,
+  })
+
+  if (item?.standard === 'spore') {
+    return (
+      <img
+        src={isLoading ? DEFAULT_SPORE_IMAGE : dobImg}
+        alt="cover"
+        loading="lazy"
+        className={styles.cover}
+        data-size={size}
+      />
+    )
+  }
+
+  const coverUrl = item.icon_url ?? info?.icon_url
+
+  if (coverUrl) {
+    return (
+      <img
+        src={`${patchMibaoImg(coverUrl)}?size=small&tid=${item.token_id}`}
+        alt="cover"
+        loading="lazy"
+        className={styles.cover}
+        onError={handleNftImgError}
+        data-size={size}
+      />
+    )
+  }
+
+  return <CoverIcon className={styles.cover} />
+}
+
+export default Cover

--- a/src/pages/NftCollectionInfo/ItemCover/styles.module.scss
+++ b/src/pages/NftCollectionInfo/ItemCover/styles.module.scss
@@ -1,0 +1,18 @@
+.cover {
+  object-fit: cover;
+
+  &[data-size='lg'] {
+    width: 192px;
+    height: 192px;
+    border-radius: 8px;
+  }
+
+  &[data-size='sm'] {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    margin-right: 6px;
+    flex-shrink: 0;
+    object-fit: cover;
+  }
+}

--- a/src/pages/NftCollectionInfo/NftCollectionInventory/index.tsx
+++ b/src/pages/NftCollectionInfo/NftCollectionInventory/index.tsx
@@ -1,12 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { Link } from '../../../components/Link'
-import { getImgFromSporeCell } from '../../../utils/spore'
-import { ReactComponent as Cover } from '../../../assets/nft_cover.svg'
 import styles from './styles.module.scss'
 import { getPrimaryColor } from '../../../constants/common'
 import { type NFTItem, explorerService } from '../../../services/ExplorerService'
-import { formatNftDisplayId, handleNftImgError, hexToBase64, patchMibaoImg } from '../../../utils/util'
+import { formatNftDisplayId } from '../../../utils/util'
+import Cover from '../ItemCover'
 
 const primaryColor = getPrimaryColor()
 
@@ -36,50 +35,6 @@ const NftCollectionInventory: React.FC<{
     )
   }
 
-  const renderCover = (item: NFTItem) => {
-    const coverUrl = item.icon_url ?? info?.icon_url
-    const cell = item?.cell
-    const standard = item?.standard
-    if (item.dob) {
-      const { dob } = item
-
-      const src = dob.asset?.startsWith('0x')
-        ? `data:${dob.media_type};base64,${hexToBase64(dob.asset.slice(2))}`
-        : dob.asset
-
-      return (
-        <img
-          src={src}
-          alt="cover"
-          loading="lazy"
-          className={styles.cover}
-          style={{
-            background: dob['prev.bgcolor'] ?? 'transparent',
-          }}
-        />
-      )
-    }
-
-    if (standard === 'spore' && cell && cell.data) {
-      const img = getImgFromSporeCell(cell.data)
-      return <img src={img} alt="cover" loading="lazy" className={styles.cover} />
-    }
-
-    if (coverUrl) {
-      return (
-        <img
-          src={`${patchMibaoImg(coverUrl)}?size=small&tid=${item.token_id}`}
-          alt="cover"
-          loading="lazy"
-          className={styles.cover}
-          onError={handleNftImgError}
-        />
-      )
-    }
-
-    return <Cover className={styles.cover} />
-  }
-
   return (
     <div className={styles.list}>
       {list.map(item => {
@@ -87,7 +42,9 @@ const NftCollectionInventory: React.FC<{
         const itemLink = `/nft-info/${collection}/${itemId}`
         return (
           <div key={item.id} className={styles.item}>
-            <Link to={itemLink}>{renderCover(item)}</Link>
+            <Link to={itemLink}>
+              <Cover item={item} info={info} />
+            </Link>
             <div className={styles.tokenId}>
               <span>Token ID</span>
               <Link

--- a/src/pages/NftCollectionInfo/NftCollectionInventory/styles.module.scss
+++ b/src/pages/NftCollectionInfo/NftCollectionInventory/styles.module.scss
@@ -20,13 +20,6 @@
     margin-bottom: 20px;
   }
 
-  .cover {
-    width: 192px;
-    height: 192px;
-    border-radius: 8px;
-    object-fit: cover;
-  }
-
   .tokenId,
   .owner {
     display: flex;

--- a/src/pages/NftCollectionInfo/NftCollectionTransfers/index.tsx
+++ b/src/pages/NftCollectionInfo/NftCollectionTransfers/index.tsx
@@ -3,15 +3,15 @@ import { useQuery } from '@tanstack/react-query'
 import { Tooltip } from 'antd'
 import { useTranslation } from 'react-i18next'
 import { Link } from '../../../components/Link'
-import { getImgFromSporeCell } from '../../../utils/spore'
 // TODO: Refactor is needed. Should not directly import anything from the descendants of ExplorerService.
 import styles from './styles.module.scss'
 import { getPrimaryColor } from '../../../constants/common'
-import { formatNftDisplayId, handleNftImgError, hexToBase64, patchMibaoImg } from '../../../utils/util'
+import { formatNftDisplayId } from '../../../utils/util'
 import { type TransferListRes, TransferRes, explorerService } from '../../../services/ExplorerService'
 import { dayjs } from '../../../utils/date'
 import { useParsedDate, useTimestamp } from '../../../hooks'
 import { useCurrentLanguage } from '../../../utils/i18n'
+import Cover from '../ItemCover'
 
 const primaryColor = getPrimaryColor()
 
@@ -40,7 +40,7 @@ const NftCollectionTransfers: FC<TransferCollectionProps> = props => {
 }
 NftCollectionTransfers.displayName = 'NftTransfers'
 
-const TransferTable: FC<TransferCollectionProps> = ({ standard, collection, iconURL, list, isLoading }) => {
+const TransferTable: FC<TransferCollectionProps> = ({ standard, collection, list, isLoading }) => {
   const [isShowInAge, setIsShowInAge] = useState(false)
   const { t } = useTranslation()
   const currentLanguage = useCurrentLanguage()
@@ -73,13 +73,7 @@ const TransferTable: FC<TransferCollectionProps> = ({ standard, collection, icon
       <tbody>
         {list.length ? (
           list.map(item => (
-            <TransferTableRow
-              key={item.id}
-              collection={collection}
-              item={item}
-              iconURL={iconURL}
-              isShowInAge={isShowInAge}
-            />
+            <TransferTableRow key={item.id} collection={collection} item={item} isShowInAge={isShowInAge} />
           ))
         ) : (
           <tr>
@@ -96,63 +90,13 @@ const TransferTable: FC<TransferCollectionProps> = ({ standard, collection, icon
 const TransferTableRow: FC<{
   collection: string
   item: TransferRes
-  iconURL?: string | null
   isShowInAge?: boolean
-}> = ({ collection, item, iconURL, isShowInAge }) => {
+}> = ({ collection, item, isShowInAge }) => {
   const { t } = useTranslation()
-  let coverUrl = item.item.icon_url ?? iconURL
-  if (item.item.standard === 'spore' && item.item.cell?.data) {
-    coverUrl = getImgFromSporeCell(item.item.cell.data)
-  }
   const parsedBlockCreateAt = useParsedDate(item.transaction.block_timestamp)
   const now = useTimestamp()
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const timeRelativeBlockCreate = useMemo(() => dayjs(item.transaction.block_timestamp).fromNow(), [now])
-
-  const renderCover = () => {
-    const cell = item.item?.cell
-    const standard = item.item?.standard
-
-    if (item.item.dob) {
-      const { dob } = item.item
-      const src = dob.asset?.startsWith('0x')
-        ? `data:${dob.media_type};base64,${hexToBase64(dob.asset.slice(2))}`
-        : dob.asset
-
-      return (
-        <img
-          src={src}
-          alt="cover"
-          loading="lazy"
-          className={styles.icon}
-          style={{
-            background: dob['prev.bgcolor'] ?? 'transparent',
-            padding: 2,
-          }}
-        />
-      )
-    }
-
-    if (standard === 'spore' && cell && cell.data) {
-      const img = getImgFromSporeCell(cell.data)
-      return <img src={img} alt="cover" loading="lazy" className={styles.icon} />
-    }
-
-    if (coverUrl) {
-      return (
-        <img
-          data-protocol={standard}
-          src={`${patchMibaoImg(coverUrl)}?size=small&tid=${item.item.token_id}`}
-          alt="cover"
-          loading="lazy"
-          className={styles.icon}
-          onError={handleNftImgError}
-        />
-      )
-    }
-
-    return <img src="/images/nft_placeholder.png" alt="cover" loading="lazy" className={styles.icon} />
-  }
 
   const itemId = formatNftDisplayId(item.item.token_id, item.item.standard)
 
@@ -160,7 +104,7 @@ const TransferTableRow: FC<{
     <tr>
       <td>
         <div className={styles.item}>
-          {renderCover()}
+          <Cover item={item.item} size="sm" />
           <Link
             to={`/nft-info/${collection}/${itemId}`}
             style={{
@@ -228,12 +172,12 @@ const TransferTableRow: FC<{
   )
 }
 
-const TransferCardGroup: FC<TransferCollectionProps> = ({ collection, iconURL, list, isLoading }) => {
+const TransferCardGroup: FC<TransferCollectionProps> = ({ collection, list, isLoading }) => {
   const { t } = useTranslation()
   return (
     <ul>
       {list.length ? (
-        list.map(item => <TransferCard key={item.id} collection={collection} item={item} iconURL={iconURL} />)
+        list.map(item => <TransferCard key={item.id} collection={collection} item={item} />)
       ) : (
         <li className={styles.noRecord}>{isLoading ? t('nft.loading') : t(`nft.no_record`)}</li>
       )}
@@ -244,60 +188,16 @@ const TransferCardGroup: FC<TransferCollectionProps> = ({ collection, iconURL, l
 const TransferCard: FC<{
   collection: string
   item: TransferRes
-  iconURL?: string | null
-}> = ({ collection, item, iconURL }) => {
+}> = ({ collection, item }) => {
   const { t } = useTranslation()
-  const coverUrl = item.item.icon_url ?? iconURL
   const parsedBlockCreateAt = useParsedDate(item.transaction.block_timestamp)
 
-  const renderCover = () => {
-    const cell = item.item?.cell
-    const standard = item.item?.standard
-
-    if (item.item?.dob) {
-      const { dob } = item.item
-      const src = dob.asset?.startsWith('0x')
-        ? `data:${dob.media_type};base64,${hexToBase64(dob.asset.slice(2))}`
-        : dob.asset
-
-      return (
-        <img
-          src={src}
-          alt="cover"
-          loading="lazy"
-          className={styles.icon}
-          style={{
-            background: dob['prev.bgcolor'] ?? 'transparent',
-          }}
-        />
-      )
-    }
-
-    if (standard === 'spore' && cell && cell.data) {
-      const img = getImgFromSporeCell(cell.data)
-      return <img src={img} alt="cover" loading="lazy" className={styles.icon} />
-    }
-
-    if (coverUrl) {
-      return (
-        <img
-          src={`${patchMibaoImg(coverUrl)}?size=small&tid=${item.item.token_id}`}
-          alt="cover"
-          loading="lazy"
-          className={styles.icon}
-          onError={handleNftImgError}
-        />
-      )
-    }
-
-    return <img src="/images/nft_placeholder.png" alt="cover" loading="lazy" className={styles.icon} />
-  }
   const itemId = formatNftDisplayId(item.item.token_id, item.item.standard)
 
   return (
     <li>
       <div className={styles.item}>
-        {renderCover()}
+        <Cover item={item.item} size="sm" />
         <Link
           to={`/nft-info/${collection}/${itemId}`}
           style={{

--- a/src/pages/NftCollectionInfo/NftCollectionTransfers/styles.module.scss
+++ b/src/pages/NftCollectionInfo/NftCollectionTransfers/styles.module.scss
@@ -52,24 +52,7 @@
     display: flex;
     align-items: center;
     white-space: nowrap;
-  }
-
-  .icon,
-  .defaultIcon {
-    display: inline-flex;
-    width: 30px;
-    height: 30px;
-    border-radius: 50%;
-    margin-right: 6px;
-    flex-shrink: 0;
-    object-fit: cover;
-  }
-
-  .defaultIcon {
-    background-color: #f0f0f0;
-    justify-content: center;
-    align-items: center;
-    text-transform: capitalize;
+    gap: 6px;
   }
 
   .noRecord {

--- a/src/pages/NftInfo/Cover/index.tsx
+++ b/src/pages/NftInfo/Cover/index.tsx
@@ -1,0 +1,49 @@
+import { type FC } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { DEFAULT_SPORE_IMAGE } from '../../../constants/common'
+import { NFTItem } from '../../../services/ExplorerService'
+import { getSporeImg } from '../../../utils/spore'
+import { handleNftImgError, patchMibaoImg } from '../../../utils/util'
+import { ReactComponent as CoverIcon } from '../../../assets/nft_cover.svg'
+import styles from './styles.module.scss'
+
+const Cover: FC<{
+  item: NFTItem | null
+}> = ({ item }) => {
+  const dobRenderParams =
+    item?.standard === 'spore' && item.cell?.data
+      ? {
+          data: item.cell.data,
+          id: item.type_script.args,
+        }
+      : null
+
+  const { data: dobRenderImage, isLoading } = useQuery({
+    queryKey: ['dob_render_img', dobRenderParams],
+    queryFn: () => (dobRenderParams ? getSporeImg(dobRenderParams) : DEFAULT_SPORE_IMAGE),
+    enabled: !!dobRenderParams,
+  })
+
+  if (item?.standard === 'spore') {
+    return (
+      <img src={isLoading ? DEFAULT_SPORE_IMAGE : dobRenderImage} alt="cover" loading="lazy" className={styles.cover} />
+    )
+  }
+
+  const url = item?.icon_url || item?.collection.icon_url
+  if (url) {
+    return (
+      <img
+        src={`${patchMibaoImg(url)}?size=medium&tid=${item?.token_id}`}
+        alt="cover"
+        loading="lazy"
+        className={styles.cover}
+        onError={handleNftImgError}
+      />
+    )
+  }
+
+  return <CoverIcon className={styles.cover} />
+}
+
+export default Cover

--- a/src/pages/NftInfo/Cover/styles.module.scss
+++ b/src/pages/NftInfo/Cover/styles.module.scss
@@ -1,0 +1,20 @@
+@import '../../../styles/variables.module';
+
+.cover {
+  width: 440px;
+  height: 440px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  object-fit: scale-down;
+  background: #fafafa;
+
+  @media (width <= $largeBreakPoint) {
+    width: 360px;
+    height: 360px;
+  }
+
+  @media (width <= $mobileBreakPoint) {
+    width: 100%;
+    height: auto;
+  }
+}

--- a/src/pages/NftInfo/index.tsx
+++ b/src/pages/NftInfo/index.tsx
@@ -2,20 +2,18 @@ import { useParams, useHistory } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Tooltip } from 'antd'
 import { useTranslation } from 'react-i18next'
-import { useEffect, useState } from 'react'
 import { Link } from '../../components/Link'
 import NftItemTransfers from './NftItemTransfers'
 import Pagination from '../../components/Pagination'
-import { ReactComponent as Cover } from '../../assets/nft_cover.svg'
 import { explorerService } from '../../services/ExplorerService'
-import { DEFAULT_SPORE_IMAGE, getPrimaryColor } from '../../constants/common'
+import { getPrimaryColor } from '../../constants/common'
 import styles from './styles.module.scss'
-import { patchMibaoImg, handleNftImgError, formatNftDisplayId, hexToBase64 } from '../../utils/util'
-import { getSporeImgFromRenderSDK } from '../../utils/spore'
 import { useSearchParams } from '../../hooks'
 import DobTraits from '../../components/DobTraits'
 import { DEPRECATED_DOB_COLLECTION } from '../../constants/marks'
 import Annotation from '../../components/Annotation'
+import Cover from './Cover'
+import { formatNftDisplayId } from '../../utils/util'
 
 const primaryColor = getPrimaryColor()
 const UNIQUE_ITEM_LABEL = 'Unique Item'
@@ -28,9 +26,8 @@ const NftInfo = () => {
     i18n: { language },
   } = useTranslation()
 
-  const [sporeImg, setSporeImg] = useState(DEFAULT_SPORE_IMAGE)
-
   const { page = '1' } = useSearchParams('page')
+
   const { data } = useQuery(['nft-item-info', collection, id], () =>
     explorerService.api.fetchNFTCollectionItem(collection, id),
   )
@@ -46,68 +43,13 @@ const NftInfo = () => {
     }
     history.push(`/${language}/nft-info/${collection}/${id}?page=${pageNo}`)
   }
-  const coverUrl = data?.icon_url || data?.collection.icon_url
-  const dob = data?.dob
-
-  useEffect(() => {
-    const fetchRendedDOBImage = async () => {
-      const cell = data?.cell
-      if (cell?.data && data?.type_script.args) {
-        const renderedImg = await getSporeImgFromRenderSDK(cell.data, data?.type_script.args)
-        setSporeImg(renderedImg)
-      }
-    }
-
-    if (data) {
-      fetchRendedDOBImage()
-    }
-  }, [data])
-
-  const renderCover = () => {
-    if (dob) {
-      const src = dob.asset?.startsWith('0x')
-        ? `data:${dob.media_type};base64,${hexToBase64(dob.asset.slice(2))}`
-        : dob.asset
-
-      return (
-        <img
-          src={src}
-          alt="cover"
-          loading="lazy"
-          className={styles.cover}
-          style={{
-            background: dob['prev.bgcolor'] ?? 'transparent',
-          }}
-        />
-      )
-    }
-    const cell = data?.cell
-    const standard = data?.standard
-    if (standard === 'spore' && cell && cell.data) {
-      return <img src={sporeImg} alt="cover" loading="lazy" className={styles.cover} />
-    }
-
-    if (coverUrl) {
-      return (
-        <img
-          src={`${patchMibaoImg(coverUrl)}?size=medium&tid=${data?.token_id}`}
-          alt="cover"
-          loading="lazy"
-          className={styles.cover}
-          onError={handleNftImgError}
-        />
-      )
-    }
-
-    return <Cover className={styles.cover} />
-  }
 
   const annotation = DEPRECATED_DOB_COLLECTION.find(item => item.id === collection)
 
   return (
     <div className={styles.container}>
       <div className={styles.overview}>
-        {renderCover()}
+        <Cover item={data ?? null} />
         <div className={styles.info}>
           <div className={styles.name}>
             {data
@@ -173,10 +115,10 @@ const NftInfo = () => {
                 {data ? t(`nft.${data.collection.standard === 'spore' ? 'dob' : data.collection.standard}`) : '-'}
               </div>
             </div>
-            {dob ? (
+            {data?.dob ? (
               <div className={styles.item}>
                 <div>{t('nft.traits')}</div>
-                <DobTraits dob={dob} />
+                <DobTraits dob={data.dob} />
               </div>
             ) : null}
             {annotation ? (

--- a/src/pages/NftInfo/styles.module.scss
+++ b/src/pages/NftInfo/styles.module.scss
@@ -32,15 +32,6 @@
     width: 100%;
   }
 
-  .cover {
-    width: 440px;
-    height: 440px;
-    flex-shrink: 0;
-    border-radius: 8px;
-    object-fit: scale-down;
-    background: #fafafa;
-  }
-
   .name {
     font-size: 24px;
     font-weight: 500;

--- a/src/utils/spore.ts
+++ b/src/utils/spore.ts
@@ -70,28 +70,11 @@ export function parseSporeCellData(hexData: string) {
   return { contentType, content }
 }
 
-export const getImgFromSporeCell = (hexData: string) => {
-  const DEFAULT_URL = '/images/spore_placeholder.svg'
-  const { contentType, content } = parseSporeCellData(hexData)
-  if (contentType.startsWith('image')) {
-    const base64Data = hexToBase64(content)
-    return `data:${contentType};base64,${base64Data}`
-  }
-  if (contentType === 'application/json') {
-    try {
-      const raw: any = JSON.parse(hexToUtf8(`0x${content}`))
-      if (raw?.resource?.type?.startsWith('image')) {
-        return raw.resource?.url ?? DEFAULT_URL
-      }
-    } catch {
-      return DEFAULT_URL
-    }
-  }
-
-  return DEFAULT_URL
-}
-
-export const getSporeImgFromRenderSDK = async (hexData: string, sporeId: string) => {
+/*
+ * data: cell data
+ * id: cell.type_script.args
+ */
+export const getSporeImg = async ({ data: hexData, id: sporeId }: { data: string; id: string }): Promise<string> => {
   const DEFAULT_URL = '/images/spore_placeholder.svg'
   if (!hexData && !sporeId) {
     return DEFAULT_URL

--- a/yarn.lock
+++ b/yarn.lock
@@ -3781,6 +3781,15 @@
     pump "^3.0.0"
     tar-fs "^2.1.1"
 
+"@nervina-labs/dob-render@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@nervina-labs/dob-render/-/dob-render-0.2.3.tgz#d0539088c7f0440a5153a9b6bd0b475823a8c292"
+  integrity sha512-wTxW0oZLsHOVTn/K2iompsxUoBUYS+L8slTXzyjIoEVr7MJTHb9eUDfLRXaI9hsCoe7CcIf9fwB8TUijGTULEQ==
+  dependencies:
+    satori "^0.10.13"
+    svgson "^5.3.1"
+    typescript "^5.2.2"
+
 "@nervosnetwork/ckb-sdk-core@0.109.1":
   version "0.109.1"
   resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-sdk-core/-/ckb-sdk-core-0.109.1.tgz#9da22c2f936fcae7cc72771c70b2115e9d048dcc"
@@ -4527,6 +4536,14 @@
     "@sentry/bundler-plugin-core" "2.18.0"
     unplugin "1.0.1"
     uuid "^9.0.0"
+
+"@shuding/opentype.js@1.4.0-beta.0":
+  version "1.4.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz#5d1e7e9e056f546aad41df1c5043f8f85d39e24b"
+  integrity sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==
+  dependencies:
+    fflate "^0.7.3"
+    string.prototype.codepointat "^0.2.1"
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
@@ -7579,6 +7596,11 @@ base16@^1.0.0:
   resolved "https://registry.yarnpkg.com/base16/-/base16-1.0.0.tgz#e297f60d7ec1014a7a971a39ebc8a98c0b681e70"
   integrity sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ==
 
+base64-js@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
+  integrity sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -8604,12 +8626,22 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+css-background-parser@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/css-background-parser/-/css-background-parser-0.1.0.tgz#48a17f7fe6d4d4f1bca3177ddf16c5617950741b"
+  integrity sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==
+
 css-blank-pseudo@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-3.0.3.tgz#36523b01c12a25d812df343a32c322d2a2324561"
   integrity sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==
   dependencies:
     postcss-selector-parser "^6.0.9"
+
+css-box-shadow@1.0.0-3:
+  version "1.0.0-3"
+  resolved "https://registry.yarnpkg.com/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz#9eaeb7140947bf5d649fc49a19e4bbaa5f602713"
+  integrity sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==
 
 css-color-keywords@^1.0.0:
   version "1.0.0"
@@ -8959,6 +8991,14 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deep-rename-keys@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/deep-rename-keys/-/deep-rename-keys-0.2.1.tgz#ede78537d7a66a2be61517e2af956d7f58a3f1d8"
+  integrity sha512-RHd9ABw4Fvk+gYDWqwOftG849x0bYOySl/RgX0tLI9i27ZIeSO91mLZJEp7oPHOMFqHvpgu21YptmDt0FYD/0A==
+  dependencies:
+    kind-of "^3.0.2"
+    rename-keys "^1.1.2"
 
 deepmerge@^4.2.2:
   version "4.2.2"
@@ -9460,6 +9500,11 @@ emittery@^0.8.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
   integrity sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==
 
+emoji-regex@^10.2.1:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.4.0.tgz#03553afea80b3975749cfcb36f776ca268e413d4"
+  integrity sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -9766,7 +9811,7 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
@@ -10255,6 +10300,11 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
+eventemitter3@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  integrity sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==
+
 eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
@@ -10495,6 +10545,11 @@ fetch-retry@^5.0.2:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/fetch-retry/-/fetch-retry-5.0.6.tgz#17d0bc90423405b7a88b74355bf364acd2a7fa56"
   integrity sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==
+
+fflate@^0.7.3:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.7.4.tgz#61587e5d958fdabb5a9368a302c25363f4f69f50"
+  integrity sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -11242,6 +11297,11 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+hex-rgb@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/hex-rgb/-/hex-rgb-4.3.0.tgz#af5e974e83bb2fefe44d55182b004ec818c07776"
+  integrity sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==
+
 history@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
@@ -11695,6 +11755,11 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
@@ -12876,6 +12941,13 @@ keyv@^4.5.4:
   dependencies:
     json-buffer "3.0.1"
 
+kind-of@^3.0.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==
+  dependencies:
+    is-buffer "^1.1.5"
+
 kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
@@ -12967,6 +13039,14 @@ lilconfig@^2.0.3, lilconfig@^2.0.5, lilconfig@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
   integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
+
+linebreak@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/linebreak/-/linebreak-1.1.0.tgz#831cf378d98bced381d8ab118f852bd50d81e46b"
+  integrity sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==
+  dependencies:
+    base64-js "0.0.8"
+    unicode-trie "^2.0.0"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -14105,7 +14185,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pako@~0.2.0:
+pako@^0.2.5, pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
   integrity sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==
@@ -14136,6 +14216,14 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.7:
     hash-base "~3.0"
     pbkdf2 "^3.1.2"
     safe-buffer "^5.2.1"
+
+parse-css-color@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/parse-css-color/-/parse-css-color-0.2.1.tgz#b687a583f2e42e66ffdfce80a570706966e807c9"
+  integrity sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==
+  dependencies:
+    color-name "^1.1.4"
+    hex-rgb "^4.1.0"
 
 parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
@@ -16319,6 +16407,11 @@ remark-slug@^6.0.0:
     mdast-util-to-string "^1.0.0"
     unist-util-visit "^2.0.0"
 
+rename-keys@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/rename-keys/-/rename-keys-1.2.0.tgz#be602fb0b750476b513ebe85ba4465d03254f0a3"
+  integrity sha512-U7XpAktpbSgHTRSNRrjKSrjYkZKuhUukfoBlXWXUExCAqhzh1TU3BDRAfJmarcl5voKS+pbKU9MvyLWKZ4UEEg==
+
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-3.0.0.tgz#5fd823e4d6951d37358ecc9a58b1f06836b6268a"
@@ -16590,6 +16683,22 @@ sass@1.77.5:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
+
+satori@^0.10.13:
+  version "0.10.14"
+  resolved "https://registry.yarnpkg.com/satori/-/satori-0.10.14.tgz#5e508a86eb172c1ae7209e2c1fac62aed127c579"
+  integrity sha512-abovcqmwl97WKioxpkfuMeZmndB1TuDFY/R+FymrZyiGP+pMYomvgSzVPnbNMWHHESOPosVHGL352oFbdAnJcA==
+  dependencies:
+    "@shuding/opentype.js" "1.4.0-beta.0"
+    css-background-parser "^0.1.0"
+    css-box-shadow "1.0.0-3"
+    css-to-react-native "^3.0.0"
+    emoji-regex "^10.2.1"
+    escape-html "^1.0.3"
+    linebreak "^1.1.0"
+    parse-css-color "^0.2.1"
+    postcss-value-parser "^4.2.0"
+    yoga-wasm-web "^0.3.3"
 
 sax@~1.2.4:
   version "1.2.4"
@@ -17132,6 +17241,11 @@ string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
+string.prototype.codepointat@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz#004ad44c8afc727527b108cd462b4d971cd469bc"
+  integrity sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==
+
 string.prototype.matchall@^4.0.6, string.prototype.matchall@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
@@ -17562,6 +17676,14 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
+svgson@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/svgson/-/svgson-5.3.1.tgz#f3df0303231f2e99e4618983cfa7e8db155f79d7"
+  integrity sha512-qdPgvUNWb40gWktBJnbJRelWcPzkLed/ShhnRsjbayXz8OtdPOzbil9jtiZdrYvSDumAz/VNQr6JaNfPx/gvPA==
+  dependencies:
+    deep-rename-keys "^0.2.1"
+    xml-reader "2.4.3"
+
 swc-loader@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/swc-loader/-/swc-loader-0.2.3.tgz#6792f1c2e4c9ae9bf9b933b3e010210e270c186d"
@@ -17806,6 +17928,11 @@ timezone-mock@^1.1.4:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/timezone-mock/-/timezone-mock-1.3.6.tgz#44e4c5aeb57e6c07ae630a05c528fc4d9aab86f4"
   integrity sha512-YcloWmZfLD9Li5m2VcobkCDNVaLMx8ohAb/97l/wYS3m+0TIEK5PFNMZZfRcusc6sFjIfxu8qcJT0CNnOdpqmg==
+
+tiny-inflate@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
+  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
 tiny-invariant@^1.0.2:
   version "1.1.0"
@@ -18099,6 +18226,11 @@ typescript@4.9.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
+typescript@^5.2.2:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
+
 typescript@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
@@ -18166,6 +18298,14 @@ unicode-property-aliases-ecmascript@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
+
+unicode-trie@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-trie/-/unicode-trie-2.0.0.tgz#8fd8845696e2e14a8b67d78fa9e0dd2cad62fec8"
+  integrity sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==
+  dependencies:
+    pako "^0.2.5"
+    tiny-inflate "^1.0.0"
 
 unique-string@^2.0.0:
   version "2.0.0"
@@ -19010,10 +19150,25 @@ ws@^8.2.3, ws@^8.4.2:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
+xml-lexer@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xml-lexer/-/xml-lexer-0.2.2.tgz#518193a4aa334d58fc7d248b549079b89907e046"
+  integrity sha512-G0i98epIwiUEiKmMcavmVdhtymW+pCAohMRgybyIME9ygfVu8QheIi+YoQh3ngiThsT0SQzJT4R0sKDEv8Ou0w==
+  dependencies:
+    eventemitter3 "^2.0.0"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml-reader@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/xml-reader/-/xml-reader-2.4.3.tgz#9f810caf7c425a5aafb848b1c45103c9e71d7530"
+  integrity sha512-xWldrIxjeAMAu6+HSf9t50ot1uL5M+BtOidRCWHXIeewvSeIpscWCsp4Zxjk8kHHhdqFBrfK8U0EJeCcnyQ/gA==
+  dependencies:
+    eventemitter3 "^2.0.0"
+    xml-lexer "^0.2.2"
 
 xmlchars@^2.2.0:
   version "2.2.0"
@@ -19133,6 +19288,11 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+yoga-wasm-web@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz#eb8e9fcb18e5e651994732f19a220cb885d932ba"
+  integrity sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==
 
 zrender@4.3.2, zrender@^4.0.4:
   version "4.3.2"


### PR DESCRIPTION
This pull request introduces several changes to integrate and utilize the `@nervina-labs/dob-render` package for rendering images. The changes include mocking the package for tests, updating dependencies, and refactoring multiple components to use the new image rendering logic.

### Integration of `@nervina-labs/dob-render` package:

* [`jest.setup.js`](diffhunk://#diff-4c3cfde2c8298e64ca709feb98ce653c1f25d523dc113f5fc097d9314ec785efR4-R13): Mocked the `@nervina-labs/dob-render` package for testing purposes.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17): Added `@nervina-labs/dob-render` as a dependency and updated Jest configuration to handle the new package. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L141-R149)

### Refactoring components to use `@nervina-labs/dob-render`:

* [`src/pages/Address/AddressAssetComp.tsx`](diffhunk://#diff-46293bb294ae13f4155394be5c1204aae928b59ce6b023d5a8a87d2dbff76363R3-R14): Refactored to use `useQuery` for fetching images via `@nervina-labs/dob-render` and updated the component to handle new image rendering logic. [[1]](diffhunk://#diff-46293bb294ae13f4155394be5c1204aae928b59ce6b023d5a8a87d2dbff76363R3-R14) [[2]](diffhunk://#diff-46293bb294ae13f4155394be5c1204aae928b59ce6b023d5a8a87d2dbff76363L115-R130) [[3]](diffhunk://#diff-46293bb294ae13f4155394be5c1204aae928b59ce6b023d5a8a87d2dbff76363L146-R140)
* [`src/pages/NftCollectionInfo/ItemCover/index.tsx`](diffhunk://#diff-5f7885230ae4f4e65630eedc152a9fa57d98ecfa037996af68e784ce5ef54866R1-R56): Created a new `Cover` component that uses `@nervina-labs/dob-render` for rendering images.
* [`src/pages/NftCollectionInfo/NftCollectionInventory/index.tsx`](diffhunk://#diff-61e325c3197dc9ee80e76438c2db71d789bc4d99150f704c12333c7f297aa519L4-R8): Updated to use the new `Cover` component for rendering images. [[1]](diffhunk://#diff-61e325c3197dc9ee80e76438c2db71d789bc4d99150f704c12333c7f297aa519L4-R8) [[2]](diffhunk://#diff-61e325c3197dc9ee80e76438c2db71d789bc4d99150f704c12333c7f297aa519L39-R47)
* [`src/pages/NftCollectionInfo/NftCollectionTransfers/index.tsx`](diffhunk://#diff-72708700024c2137dc9bd90f0078e24f4f0157bc6d6d8e14b4524a1d35c81248L6-R14): Updated to use the new `Cover` component for rendering images. [[1]](diffhunk://#diff-72708700024c2137dc9bd90f0078e24f4f0157bc6d6d8e14b4524a1d35c81248L6-R14) [[2]](diffhunk://#diff-72708700024c2137dc9bd90f0078e24f4f0157bc6d6d8e14b4524a1d35c81248L43-R43) [[3]](diffhunk://#diff-72708700024c2137dc9bd90f0078e24f4f0157bc6d6d8e14b4524a1d35c81248L76-R76) [[4]](diffhunk://#diff-72708700024c2137dc9bd90f0078e24f4f0157bc6d6d8e14b4524a1d35c81248L99-R107) [[5]](diffhunk://#diff-72708700024c2137dc9bd90f0078e24f4f0157bc6d6d8e14b4524a1d35c81248L231-R180) [[6]](diffhunk://#diff-72708700024c2137dc9bd90f0078e24f4f0157bc6d6d8e14b4524a1d35c81248L247-R200)
* [`src/pages/NftInfo/Cover/index.tsx`](diffhunk://#diff-552175a775255f4808b7e6d02f8275f3365a4da09b52000ec6d090ecce1a6041R1-R49): Created a new `Cover` component that uses `@nervina-labs/dob-render` for rendering images.

### Addition of constants:

* [`src/constants/common.ts`](diffhunk://#diff-9b9a49cd15349e68109f9c49f06bbda53dc9f38b4885771124ee55a2cf0dbf27R176-R177): Added a new constant `DEFAULT_SPORE_IMAGE` for default image handling.

### Minor adjustments and cleanups:

* [`src/models/Address/UDTAccount.ts`](diffhunk://#diff-c15167d03794b3677c35a68676394db5dbe68c381f9b5d8e6552999473bce684R1-R2): Added `udtTypeScript` to the `Spore` interface. [[1]](diffhunk://#diff-c15167d03794b3677c35a68676394db5dbe68c381f9b5d8e6552999473bce684R1-R2) [[2]](diffhunk://#diff-c15167d03794b3677c35a68676394db5dbe68c381f9b5d8e6552999473bce684R59)
* [`src/pages/NftCollectionInfo/NftCollectionInventory/styles.module.scss`](diffhunk://#diff-7a23b7b5e75104a457686cfc2ec1ddbb2b6f11050f0b310e5711f55e038493e0L23-L29): Removed old styles related to image rendering.
* [`src/pages/NftCollectionInfo/NftCollectionTransfers/styles.module.scss`](diffhunk://#diff-af0fc24c5d99453e3e5d0c080138220bbf12faa54151eb6e30a127519adefc27L55-R55): Removed old styles related to image rendering.