### PR TITLE
feat: improve NFT navigation links

### DIFF
--- a/src/pages/Address/AddressAssetComp.tsx
+++ b/src/pages/Address/AddressAssetComp.tsx
@@ -131,7 +131,7 @@ export const AddressSporeComp = ({
   return (
     <AddressAssetComp
       isRGBPP={isRGBPP ?? false}
-      href={`/nft-collections/${collection?.typeHash}`}
+      href={`/nft-info/${collection?.typeHash}/${udtTypeScript.args}`}
       property={
         isMerged ? `${t('rgbpp.amount')}: ${(+amount).toLocaleString('en')}` : `id: ${id.slice(0, 8)}...${id.slice(-8)}`
       }
@@ -164,7 +164,7 @@ export const AddressMNFTComp = ({ account, isRGBPP }: { account: MNFT; isRGBPP?:
   return (
     <AddressAssetComp
       isRGBPP={isRGBPP ?? false}
-      href={`/nft-collections/${collection?.typeHash}`}
+      href={`/nft-info/${collection?.typeHash}/${amount}`}
       property={`#${amount}`}
       name={sliceNftName(symbol)}
       udtLabel="m-NFT"
@@ -198,10 +198,12 @@ export const AddressNRC721Comp = ({ account, isRGBPP }: { account: NRC721; isRGB
       })
   }, [udtIconFile])
 
+  const id = BigInt(`0x${amount}`).toString()
+
   return (
     <AddressAssetComp
       isRGBPP={isRGBPP ?? false}
-      href={`/nft-collections/${collection?.typeHash}`}
+      href={`/nft-info/${collection?.typeHash}/${id}`}
       property={`id: ${amount}`}
       name={!symbol ? '?' : sliceNftName(`${symbol} #${collection.typeHash.slice(2, 5)}`)}
       isUnverified={!symbol}

--- a/src/pages/NftInfo/NameMissing.svg
+++ b/src/pages/NftInfo/NameMissing.svg
@@ -1,0 +1,22 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
+  <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g>
+  <g id="SVGRepo_iconCarrier">
+    <path d="M12 8L12 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+      stroke-linejoin="round"></path>
+    <path d="M12 16.01L12.01 15.9989" stroke="currentColor" stroke-width="1.5"
+      stroke-linecap="round" stroke-linejoin="round"></path>
+    <path d="M9 3H4V6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+      stroke-linejoin="round"></path>
+    <path d="M4 11V13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+      stroke-linejoin="round"></path>
+    <path d="M20 11V13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+      stroke-linejoin="round"></path>
+    <path d="M15 3H20V6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+      stroke-linejoin="round"></path>
+    <path d="M9 21H4V18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+      stroke-linejoin="round"></path>
+    <path d="M15 21H20V18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+      stroke-linejoin="round"></path>
+  </g>
+</svg>

--- a/src/pages/NftInfo/index.tsx
+++ b/src/pages/NftInfo/index.tsx
@@ -13,6 +13,7 @@ import DobTraits from '../../components/DobTraits'
 import { DEPRECATED_DOB_COLLECTION } from '../../constants/marks'
 import Annotation from '../../components/Annotation'
 import Cover from './Cover'
+import { ReactComponent as NameMissing } from './NameMissing.svg'
 import { formatNftDisplayId } from '../../utils/util'
 
 const primaryColor = getPrimaryColor()
@@ -100,6 +101,14 @@ const NftInfo = () => {
                 ) : (
                   '-'
                 )}
+              </div>
+            </div>
+            <div className={styles.item}>
+              <div>Collection</div>
+              <div>
+                <Link to={`/nft-collections/${collection}`} className={styles.collection}>
+                  {data?.collection.name ?? <NameMissing />}
+                </Link>
               </div>
             </div>
             <div className={styles.item}>

--- a/src/pages/NftInfo/styles.module.scss
+++ b/src/pages/NftInfo/styles.module.scss
@@ -114,3 +114,7 @@
 .extra {
   width: min-content;
 }
+
+.collection {
+  color: var(--primary-color);
+}


### PR DESCRIPTION
- Update address page NFT links to point directly to detail pages instead of collection pages
- Add collection link on NFT detail page for better navigation

Before:

https://github.com/user-attachments/assets/92c6c823-8782-40d4-943b-169af9240a87

 

After: 


https://github.com/user-attachments/assets/74c643f3-0750-402a-a22f-a5d6063f86ff

