### PR TITLE
feat: add title on hovering 3d cube in hardfork animation

### DIFF
--- a/src/pages/HardFork/index.tsx
+++ b/src/pages/HardFork/index.tsx
@@ -134,7 +134,9 @@ export default function CountdownPage() {
           </div>
         </div>
         <div className={styles.cubeContainer}>
-          <img src="/images/3d_cube.gif" className={styles.cube3d} alt="cube3d" />
+          <div className={styles.cube3d}>
+            <img src="/images/3d_cube.gif" alt="cube3d" />
+          </div>
         </div>
         <img className={styles.glowingLine} src={glowingLine} alt="line" />
       </div>

--- a/src/pages/HardFork/styles.module.scss
+++ b/src/pages/HardFork/styles.module.scss
@@ -338,6 +338,15 @@ $glowing-line-width: 76px;
   @media (width >= 768px) {
     height: 300px;
   }
+
+  @media screen and (width >768px) {
+    &:has(.cube3d:hover) {
+      .flatCube,
+      .cube3d {
+        animation-play-state: paused;
+      }
+    }
+  }
 }
 
 .glowingLine {
@@ -362,7 +371,7 @@ $glowing-line-width: 76px;
   z-index: 1;
   width: 50vw;
   overflow-x: hidden;
-  height: 150px;
+  height: 180px;
   box-sizing: border-box;
 
   &:first-of-type {
@@ -393,6 +402,7 @@ $glowing-line-width: 76px;
   height: min-content;
   width: min-content;
   animation: flat-cube-animation 8s ease-in-out infinite;
+  animation-play-state: running;
 
   @keyframes flat-cube-animation {
     0% {
@@ -416,8 +426,36 @@ $glowing-line-width: 76px;
 }
 
 .cube3d {
+  position: relative;
+  width: min-content;
   margin-top: 0;
   animation: cube-3d-animation 8s ease-in-out infinite;
+  animation-play-state: running;
+
+  @media screen and (width >768px) {
+    &:hover {
+      &::after {
+        display: block;
+      }
+    }
+
+    &::after {
+      display: none;
+      content: 'A New High-Dimensional CKB VM!';
+      position: absolute;
+      top: 90%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-size: 0.875rem;
+      color: #333;
+      padding: 2px 20px;
+      white-space: nowrap;
+      border-radius: 2px;
+      box-shadow: 0 0 12px 4px rgb(255 255 255 / 90%), inset 0 0 6px rgb(220 220 240 / 80%);
+      background: linear-gradient(135deg, rgb(240 240 250 / 100%), rgb(200 200 215 / 100%));
+      border: 1px solid rgb(255 255 255 / 50%);
+    }
+  }
 
   @keyframes cube-3d-animation {
     0% {


### PR DESCRIPTION
This commit is generated by claude and reviewed by @Keith-CY

This pull request includes several changes to the `src/pages/HardFork` components and styles to enhance the visual presentation and interactivity of the 3D cube element. The most important changes are grouped by theme below:

### Component Structure Updates:

* [`src/pages/HardFork/index.tsx`](diffhunk://#diff-d7da5574db24b23d7024d8831bcb94efda8850cf11700b93a114c51e73f229b7L137-R139): Wrapped the 3D cube image in a `div` container to allow for additional styling and interaction capabilities.

### Styling and Animation Enhancements:

* [`src/pages/HardFork/styles.module.scss`](diffhunk://#diff-a5342fbc3c20317344e96ea91488cff6a6116517dda49059f0e854ca18ae18bcR341-R349): Added a media query to pause the cube animation when hovered over on screens wider than 768px.
* [`src/pages/HardFork/styles.module.scss`](diffhunk://#diff-a5342fbc3c20317344e96ea91488cff6a6116517dda49059f0e854ca18ae18bcL365-R374): Increased the height of the element containing the glowing line from 150px to 180px to provide better spacing.
* [`src/pages/HardFork/styles.module.scss`](diffhunk://#diff-a5342fbc3c20317344e96ea91488cff6a6116517dda49059f0e854ca18ae18bcR405): Set the initial state of the cube animation to `running` to ensure it starts immediately.
* [`src/pages/HardFork/styles.module.scss`](diffhunk://#diff-a5342fbc3c20317344e96ea91488cff6a6116517dda49059f0e854ca18ae18bcR429-R458): Enhanced the `.cube3d` class with additional styles, including a hover effect that displays a message below the cube on larger screens. 

