### PR TITLE
fix: fix sampling of fee rate

### DIFF
--- a/src/pages/FeeRateTracker/FeeRateTrackerComp.tsx
+++ b/src/pages/FeeRateTracker/FeeRateTrackerComp.tsx
@@ -32,7 +32,7 @@ const getWeightedMedian = (tfrs: FeeRateTracker.TransactionFeeRate[]): number =>
     return 0
   }
   return tfrs.length % 2 === 0
-    ? (tfrs[tfrs.length / 2 - 1].confirmationTime + tfrs[tfrs.length / 2 - 1].confirmationTime) / 2
+    ? (tfrs[tfrs.length / 2 - 1].confirmationTime + tfrs[tfrs.length / 2].confirmationTime) / 2
     : tfrs[(tfrs.length - 1) / 2].confirmationTime
 }
 

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -117,7 +117,7 @@ export const getFeeRateSamples = (feeRates: FeeRateTracker.TransactionFeeRate[],
 
   // check if lowest fee rate has ideal confirmation time
   const lowests = validSamples.slice(0, SAMPLES_MIN_COUNT)
-  const avgOfLowests = lowests.reduce((acc, cur) => acc + cur.confirmationTime, 0) / validSamples.length
+  const avgOfLowests = lowests.reduce((acc, cur) => acc + cur.confirmationTime, 0) / lowests.length
 
   const ACCEPTABLE_CONFIRMATION_TIME = 2 * avgBlockTime
 
@@ -135,7 +135,7 @@ export const getFeeRateSamples = (feeRates: FeeRateTracker.TransactionFeeRate[],
 
   // Calculate the Interquartile Range (IQR)
   const iqr = q3 - q1
-  // // Define the lower and upper bounds for outliers
+  // Define the lower and upper bounds for outliers
   const lowerBound = q1 - 1.5 * iqr
   const upperBound = q3 + 1.5 * iqr
 


### PR DESCRIPTION
This commit is generated by Claude and reviewed by @Keith-CY

This pull request includes critical bug fixes and minor code cleanup in the `FeeRateTracker` components and utilities. The most important changes are as follows:

### Bug Fixes:

* [`src/pages/FeeRateTracker/FeeRateTrackerComp.tsx`](diffhunk://#diff-6e2fca28b9711e1003afe4b889c179ed6a4e1c6c6ed277bc8fd03d8359dc264eL35-R35): Corrected the calculation of the weighted median by fixing the index used for the second element in the even-length case.
* [`src/utils/chart.ts`](diffhunk://#diff-8debf2c975abb0289755fcd50371f1a938d517c022c908738fc83f7b7844b402L120-R120): Fixed the calculation of the average of the lowest fee rate samples by dividing by the correct length of the `lowests` array.

### Code Cleanup:

* [`src/utils/chart.ts`](diffhunk://#diff-8debf2c975abb0289755fcd50371f1a938d517c022c908738fc83f7b7844b402L138-R138): Removed an extra comment line to clean up the code.