### PR TITLE
feat: optimize hover effect on graph node list page

### DIFF
--- a/src/pages/Fiber/GraphNodeList/index.tsx
+++ b/src/pages/Fiber/GraphNodeList/index.tsx
@@ -67,7 +67,7 @@ const fields = [
             )
           })}
           {hiddens.length ? (
-            <div>
+            <div data-hover="stop-propagation">
               <span className={styles.hiddenThresholds}>
                 <span className={styles.count}>{`+${hiddens.length}`}</span>
                 <div className={styles.items}>

--- a/src/styles/table.module.scss
+++ b/src/styles/table.module.scss
@@ -40,8 +40,8 @@
   }
 
   tbody {
-    tr:hover {
-      background: #ccc;
+    tr:hover:not(:has([data-hover='stop-propagation']:hover)) {
+      background: #efefef;
     }
   }
 


### PR DESCRIPTION
block hover event propagation when hidden threshold is hovered

Before
<img width="2100" alt="image" src="https://github.com/user-attachments/assets/8d238d65-6344-4be3-be6f-7d419cf1613c" />


After
<img width="1657" alt="image" src="https://github.com/user-attachments/assets/6813ec4b-725a-4c24-a30a-3f6a54ddee08" />
