### PR TITLE
fix: fix tx status when it's not found

### DIFF
--- a/src/components/HelpTip/index.module.scss
+++ b/src/components/HelpTip/index.module.scss
@@ -8,4 +8,8 @@
   width: 15px;
   height: 15px;
   margin: 0 5px;
+
+  &:last-child {
+    margin-right: 0;
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -690,7 +690,21 @@
       "fiber_channel": "Fiber Channel",
       "deployment": "Deployment",
       "deployed_script": "Deployed Script",
-      "range_notice": "Only the latest {{count}} related items will be displayed here."
+      "range_notice": "Only the latest {{count}} related items will be displayed here.",
+      "status_label": {
+        "pending": {
+          "label": "Pending",
+          "tooltip": "The transaction is pending and has not been committed in a block yet."
+        },
+        "rejected": {
+          "label": "Rejected",
+          "tooltip": "The transaction is rejected and will not be committed in a block."
+        },
+        "untracked": {
+          "label": "Untracked",
+          "tooltip": "The transaction is untracked and please confirm with the sender"
+        }
+      }
     },
     "block": {
       "block": "Block",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -658,7 +658,21 @@
       "fiber_channel": "Fiber Channel",
       "deployment": "部署",
       "deployed_script": "部署脚本",
-      "range_notice": "只显示最近的 5,000 条相关交易"
+      "range_notice": "只显示最近的 5,000 条相关交易",
+      "status_label": {
+        "pending": {
+          "label": "待处理",
+          "tooltip": "交易尚未被提交到区块中"
+        },
+        "rejected": {
+          "label": "已拒绝",
+          "tooltip": "交易被拒绝，不会被提交到区块中"
+        },
+        "untracked": {
+          "label": "未追踪",
+          "tooltip": "交易未被浏览器追踪，请与发送方确认"
+        }
+      }
     },
     "block": {
       "block": "区块",

--- a/src/pages/Transaction/TransactionComp/TransactionOverview.tsx
+++ b/src/pages/Transaction/TransactionComp/TransactionOverview.tsx
@@ -156,45 +156,62 @@ export const TransactionOverviewCard: FC<{
     content: liteTxCyclesDataContent,
   }
   const overviewItems: CardCellInfo<'left' | 'right'>[] = []
-  if (txStatus === 'committed') {
-    overviewItems.push(blockHeightData, timestampData)
-    if (confirmation >= 0) {
-      if (isProfessional) {
-        overviewItems.push(bytes ? feeWithFeeRateData : txFeeData, txStatusData)
-      } else {
-        overviewItems.push(txStatusData)
+  switch (txStatus) {
+    case 'committed': {
+      overviewItems.push(blockHeightData, timestampData)
+      if (confirmation >= 0) {
+        if (isProfessional) {
+          overviewItems.push(bytes ? feeWithFeeRateData : txFeeData, txStatusData)
+        } else {
+          overviewItems.push(txStatusData)
+        }
       }
+      break
     }
-  } else if (txStatus === 'rejected') {
-    overviewItems.push(
-      blockHeightData,
-      {
-        ...timestampData,
-        content: 'Rejected',
-      },
-      {
+    case 'rejected': {
+      overviewItems.push(
+        blockHeightData,
+        {
+          ...timestampData,
+          content: 'Rejected',
+        },
+        {
+          ...txStatusData,
+          content: t('transaction.status_label.rejected.label'),
+          contentTooltip: detailedMessage,
+        },
+      )
+      break
+    }
+    case 'pending': {
+      // pending
+      overviewItems.push(
+        {
+          ...blockHeightData,
+          content: '···',
+        },
+        {
+          ...timestampData,
+          content: '···',
+        },
+        {
+          ...txStatusData,
+          content: t('transaction.status_label.pending.label'),
+          contentTooltip: t('transaction.status_label.pending.tooltip'),
+        },
+      )
+      break
+    }
+    default: {
+      // unknown
+      overviewItems.push({
         ...txStatusData,
-        content: 'Rejected',
-        contentTooltip: detailedMessage,
-      },
-    )
-  } else {
-    // pending
-    overviewItems.push(
-      {
-        ...blockHeightData,
-        content: '···',
-      },
-      {
-        ...timestampData,
-        content: '···',
-      },
-      {
-        ...txStatusData,
-        content: 'Pending',
-      },
-    )
+        content: t('transaction.status_label.untracked.label'),
+        contentTooltip: t('transaction.status_label.untracked.tooltip'),
+      })
+    }
   }
+
   if (isProfessional) {
     overviewItems.push(liteTxSizeData, liteTxCyclesData)
   }


### PR DESCRIPTION
Display "untracked" when the transaction is not found in tx pool instead of displaying "pending" as a fallback

Before
![image](https://github.com/user-attachments/assets/fd5692a2-43c0-44d3-923d-0ff441679ab2)

After
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/1b378cb6-3c41-4416-8a94-166bfb156aba" />
