### PR TITLE
feat: use created_timestamp as the first seen time

### DIFF
--- a/src/pages/Fiber/GraphNode/index.tsx
+++ b/src/pages/Fiber/GraphNode/index.tsx
@@ -270,7 +270,7 @@ const GraphNode = () => {
     e.preventDefault()
     navigator?.clipboard.writeText(copyText).then(() => setToast({ message: t('common.copied') }))
   }
-  const firstSeen = node.timestamp
+  const firstSeen = node.createdTimestamp
   const lastUpdate = node.deletedAtTimestamp ?? node.lastUpdatedTimestamp
   const firstSeenISO = new Date(+firstSeen).toISOString()
   const lastUpdateISO = new Date(+lastUpdate).toISOString()

--- a/src/pages/Fiber/GraphNodeList/index.tsx
+++ b/src/pages/Fiber/GraphNodeList/index.tsx
@@ -122,9 +122,9 @@ const fields = [
     key: 'timestamp',
     label: 'first_seen_last_update',
     transformer: (_: unknown, n: Fiber.Graph.Node) => {
-      const { timestamp, deletedAtTimestamp, lastUpdatedTimestamp } = n
+      const { createdTimestamp, deletedAtTimestamp, lastUpdatedTimestamp } = n
 
-      const firstSeen = timestamp
+      const firstSeen = createdTimestamp
       const lastSeen = deletedAtTimestamp ?? lastUpdatedTimestamp
 
       const firstSeenISO = new Date(+firstSeen).toISOString()

--- a/src/services/ExplorerService/types.ts
+++ b/src/services/ExplorerService/types.ts
@@ -696,6 +696,7 @@ export namespace Fiber {
       nodeName: string
       nodeId: string
       addresses: string[]
+      createdTimestamp: string
       timestamp: string
       lastUpdatedTimestamp: string
       deletedAtTimestamp: string | null


### PR DESCRIPTION
Use `created timestamp` as the first seen time because the default timestamp will be refreshed when the node broadcasts its info