### PR TITLE
feat: update total liquidity of fiber graph

### DIFF
--- a/src/__tests__/pages/Fiber/Graph/utils.test.ts
+++ b/src/__tests__/pages/Fiber/Graph/utils.test.ts
@@ -29,14 +29,16 @@ describe('Fiber Graph Utils', () => {
         {
           totalNodes: '10',
           totalChannels: '20',
-          totalLiquidity: '1000000000', // 10 CKB in shannon
+          totalCapacity: '1000000000', // 10 CKB in shannon
           createdAtUnixtimestamp: '1600000000',
+          totalLiquidity: null,
         },
         {
           totalNodes: '15',
           totalChannels: '25',
-          totalLiquidity: '2000000000', // 20 CKB in shannon
+          totalCapacity: '2000000000', // 20 CKB in shannon
           createdAtUnixtimestamp: '1600001000',
+          totalLiquidity: null,
         },
       ],
     }
@@ -47,10 +49,12 @@ describe('Fiber Graph Utils', () => {
         nodes: [],
         channels: [],
         capacity: [],
+        liquidity: [],
         latest: {
           capacity: null,
           nodes: null,
           channels: null,
+          liquidity: null,
         },
       })
     })
@@ -97,10 +101,12 @@ describe('Fiber Graph Utils', () => {
         nodes: [],
         channels: [],
         capacity: [],
+        liquidity: [],
         latest: {
           capacity: null,
           nodes: null,
           channels: null,
+          liquidity: null,
         },
       })
     })

--- a/src/pages/Fiber/Graph/HistoryChart/index.tsx
+++ b/src/pages/Fiber/Graph/HistoryChart/index.tsx
@@ -42,6 +42,7 @@ const getOption =
           type: 'line',
           yAxisIndex: 0,
           symbol: 'none',
+          smooth: true,
           symbolSize: 3,
           areaStyle: {
             opacity: 0.2,

--- a/src/pages/Fiber/Graph/index.tsx
+++ b/src/pages/Fiber/Graph/index.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { Link } from '../../../components/Link'
 import { explorerService } from '../../../services/ExplorerService'
+import { fetchPrices } from '../../../services/UtilityService'
 import { parseNumericAbbr } from '../../../utils/chart'
 import HistoryChart from './HistoryChart'
 import styles from './index.module.scss'
@@ -21,7 +22,13 @@ const FiberGraph = () => {
     refetchInterval: REFETCH_INTERVAL,
   })
 
-  const metrics = calculateGraphMetrics(data)
+  const { data: price } = useQuery({
+    queryKey: ['utility', 'prices'] as const,
+    queryFn: fetchPrices,
+    refetchInterval: 30000,
+  })
+
+  const metrics = calculateGraphMetrics(data, price)
   const last = data?.data[data?.data.length - 1]
 
   const meanAndMediumProps = {
@@ -38,10 +45,10 @@ const FiberGraph = () => {
       <div className={styles.history}>
         <div className={styles.vertical}>
           <MetricCard
-            title={t('fiber.graph.total_capacity')}
-            metric={metrics.latest.capacity}
-            chart={<HistoryChart dataset={metrics.capacity} color="#00cc9b" seriaName="CKB" />}
-            unit="CKB"
+            title={t('fiber.graph.total_liquidity')}
+            metric={metrics.latest.liquidity}
+            chart={<HistoryChart dataset={metrics.liquidity} color="#00cc9b" seriaName="USD" />}
+            unit="USD"
           />
 
           <MetricCard

--- a/src/pages/Fiber/Graph/types.ts
+++ b/src/pages/Fiber/Graph/types.ts
@@ -37,10 +37,12 @@ export interface GraphMetrics {
   nodes: Dataset[]
   channels: Dataset[]
   capacity: Dataset[]
+  liquidity: Dataset[]
   latest: {
     capacity: MetricDiff | null
     nodes: MetricDiff | null
     channels: MetricDiff | null
+    liquidity: MetricDiff | null
   }
 }
 

--- a/src/pages/Fiber/Graph/utils.ts
+++ b/src/pages/Fiber/Graph/utils.ts
@@ -1,5 +1,17 @@
+import BigNumber from 'bignumber.js'
+import { CKB_PRICE_ID, type fetchPrices } from '../../../services/UtilityService'
 import { shannonToCkb } from '../../../utils/util'
 import type { GraphMetrics } from './types'
+
+const isCKBLiquidity = (price: unknown): price is { symbol: 'CKB'; amount: string } => {
+  return (
+    typeof price === 'object' &&
+    price !== null &&
+    'symbol' in price &&
+    'amount' in price &&
+    (price as { symbol: string }).symbol === 'CKB'
+  )
+}
 
 /**
  * Gets the latest value and its difference from the previous value in a list
@@ -28,35 +40,100 @@ export const getLatest = (list: { value: string }[]): { value: string; diff: num
  * @param data - Object containing data array of graph history entries with totalNodes, totalChannels, totalLiquidity and timestamps
  * @returns GraphMetrics object with nodes, channels and capacity datasets and their latest values with diffs
  */
-export const calculateGraphMetrics = (data?: {
-  data: { totalNodes: string; totalChannels: string; totalLiquidity: string; createdAtUnixtimestamp: string }[]
-}): GraphMetrics => {
+export const calculateGraphMetrics = (
+  data?: {
+    data: {
+      totalNodes: string
+      totalChannels: string
+      totalCapacity: string
+      createdAtUnixtimestamp: string
+      totalLiquidity:
+        | (
+            | {
+                symbol: 'CKB'
+                amount: string
+              }
+            | {
+                symbol: string
+                amount: string
+                decimal: string
+                typeHash: string
+              }
+          )[]
+        | null
+    }[]
+  },
+  price?: Awaited<ReturnType<typeof fetchPrices>>,
+): GraphMetrics => {
   const nodes =
-    data?.data?.map(item => ({
-      value: item.totalNodes,
-      timestamp: item.createdAtUnixtimestamp,
-    })) ?? []
+    data?.data
+      ?.map(item => ({
+        value: item.totalNodes,
+        timestamp: item.createdAtUnixtimestamp,
+      }))
+      .sort((a, b) => (+a.timestamp > +b.timestamp ? 1 : -1)) ?? []
 
   const channels =
-    data?.data?.map(item => ({
-      value: item.totalChannels,
-      timestamp: item.createdAtUnixtimestamp,
-    })) ?? []
+    data?.data
+      ?.map(item => ({
+        value: item.totalChannels,
+        timestamp: item.createdAtUnixtimestamp,
+      }))
+      .sort((a, b) => (+a.timestamp > +b.timestamp ? 1 : -1)) ?? []
 
   const capacity =
-    data?.data?.map(item => ({
-      value: (+shannonToCkb(item.totalLiquidity)).toFixed(2),
-      timestamp: item.createdAtUnixtimestamp,
-    })) ?? []
+    data?.data
+      ?.map(item => ({
+        value: (+shannonToCkb(item.totalCapacity)).toFixed(2),
+        timestamp: item.createdAtUnixtimestamp,
+      }))
+      .sort((a, b) => (+a.timestamp > +b.timestamp ? 1 : -1)) ?? []
+
+  const liquidity =
+    data && Array.isArray(data.data) && price
+      ? data.data
+          .map(item => {
+            if (!item.totalLiquidity)
+              return {
+                value: '0',
+                timestamp: item.createdAtUnixtimestamp,
+              }
+
+            let total = BigNumber(0)
+
+            item.totalLiquidity.forEach(l => {
+              if (isCKBLiquidity(l)) {
+                const p = BigNumber(price.price[CKB_PRICE_ID]?.price)
+                const ckbAmount = BigNumber(shannonToCkb(l.amount))
+                total = total.plus(ckbAmount.multipliedBy(p))
+                return
+              }
+              const token = price.price[l.typeHash]
+              if (!token) {
+                return
+              }
+              const p = BigNumber(token.price)
+              const amount = BigNumber(l.amount).dividedBy(10 ** +l.decimal)
+              total = total.plus(amount.multipliedBy(p))
+            })
+            return {
+              value: total.toFixed(),
+              timestamp: item.createdAtUnixtimestamp,
+            }
+          })
+          .sort((a, b) => (+a.timestamp > +b.timestamp ? 1 : -1))
+      : []
 
   return {
     nodes,
     channels,
     capacity,
+    liquidity,
     latest: {
       capacity: getLatest(capacity),
       nodes: getLatest(nodes),
       channels: getLatest(channels),
+      liquidity: getLatest(liquidity),
     },
   }
 }

--- a/src/pages/Fiber/GraphNode/index.tsx
+++ b/src/pages/Fiber/GraphNode/index.tsx
@@ -14,7 +14,7 @@ import { getFundingThreshold } from '../utils'
 import { handleFtImgError, shannonToCkb } from '../../../utils/util'
 import { parseNumericAbbr } from '../../../utils/chart'
 import { formalizeChannelAsset, getIpFromP2pAddr } from '../../../utils/fiber'
-import { fetchIpsInfo, fetchPrices } from '../../../services/UtilityService'
+import { CKB_PRICE_ID, fetchIpsInfo, fetchPrices } from '../../../services/UtilityService'
 import Content from '../../../components/Content'
 import { Link } from '../../../components/Link'
 import Loading from '../../../components/Loading'
@@ -32,7 +32,6 @@ interface QueryResponse extends Response.Response<Fiber.Graph.NodeDetail> {}
 
 const CHANNEL_PAGE_SIZE = 10
 const ACTIVITY_PAGE_SIZE = 39
-const CKB_PRICE_ID = '0x0000000000000000000000000000000000000000000000000000000000000000'
 const TIME_TEMPLATE = 'YYYY-MM-DD'
 
 const useNodeData = (id: string | undefined) => {

--- a/src/services/ExplorerService/types.ts
+++ b/src/services/ExplorerService/types.ts
@@ -733,17 +733,32 @@ export namespace Fiber {
       fiberGraphChannels: Channel[]
     }
 
-    export type Statistics = Record<
+    export type Statistics = (Record<
       | 'totalNodes'
       | 'totalChannels'
-      | 'totalLiquidity'
+      | 'totalCapacity'
       | 'meanValueLocked'
       | 'meanFeeRate'
       | 'mediumValueLocked'
       | 'mediumFeeRate'
       | 'createdAtUnixtimestamp',
       string
-    >[]
+    > & {
+      totalLiquidity:
+        | (
+            | {
+                symbol: 'CKB'
+                amount: string
+              }
+            | {
+                symbol: string
+                amount: string
+                decimal: string
+                typeHash: string
+              }
+          )[]
+        | null
+    })[]
 
     export type GraphNodeIps = {
       nodeId: string

--- a/src/services/UtilityService/index.ts
+++ b/src/services/UtilityService/index.ts
@@ -49,3 +49,5 @@ export const claimTestToken = async (address: string, token: string) => {
   })
   return data
 }
+
+export const CKB_PRICE_ID = '0x0000000000000000000000000000000000000000000000000000000000000000'


### PR DESCRIPTION
use total USD liquidity instead of total capacity of CKB

Ref: https://github.com/Magickbase/ckb-explorer-public-issues/issues/838#issuecomment-2774311686

Before:
![image](https://github.com/user-attachments/assets/d001fc95-8d8b-4ff6-8f08-a04b60813563)

After:
<img width="1425" alt="image" src="https://github.com/user-attachments/assets/b8e2d26a-9136-4639-b6fc-fa6e170fbb1e" />

