### PR TITLE
feat: discard some fee rate samples when bandwidth is sufficient

### DIFF
--- a/src/pages/FeeRateTracker/FeeRateTrackerComp.tsx
+++ b/src/pages/FeeRateTracker/FeeRateTrackerComp.tsx
@@ -45,13 +45,26 @@ const colors = ChartColor.moreColors
 
 export const FeeRateCards = ({ transactionFeeRates }: { transactionFeeRates: FeeRateTracker.TransactionFeeRate[] }) => {
   const { t } = useTranslation()
-  const allFrs = transactionFeeRates.sort((a, b) => a.confirmationTime - b.confirmationTime)
+  let allFrs = transactionFeeRates.sort((a, b) => a.confirmationTime - b.confirmationTime)
+  const minFeeRate = allFrs.sort((a, b) => a.feeRate - b.feeRate)[0].feeRate
+
+  const SCALING_FACTOR = 5
+
+  const sampleWithinScale = allFrs.filter(r => r.feeRate <= minFeeRate * SCALING_FACTOR)
+  if (sampleWithinScale.length * 3 > allFrs.length) {
+    // When more than 1/3 of transactions have fee rates within 5x of the minimum,
+    // we consider the network to have sufficient bandwidth. In this case,
+    // we filter out transactions with unusually high fee rates to provide
+    // more accurate fee rate recommendations.
+    allFrs = sampleWithinScale
+  }
+
   const avgConfirmationTime = getWeightedMedian(allFrs)
 
   const lowFrs = allFrs.filter(r => r.confirmationTime >= avgConfirmationTime)
   const lowConfirmationTime = getWeightedMedian(lowFrs)
 
-  const highFrs = allFrs.filter(r => r.confirmationTime <= avgConfirmationTime)
+  const highFrs = allFrs.filter(r => r.confirmationTime < avgConfirmationTime)
   const highConfirmationTime = getWeightedMedian(highFrs)
 
   const list = [lowFrs, allFrs, highFrs].map(calcFeeRate)

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -116,7 +116,7 @@ export const getFeeRateSamples = (feeRates: FeeRateTracker.TransactionFeeRate[],
   const validSamples = feeRates.filter(i => i.confirmationTime).sort((a, b) => a.feeRate - b.feeRate)
 
   // check if lowest fee rate has ideal confirmation time
-  const lowests = validSamples.slice(0, SAMPLES_MIN_COUNT)
+  const lowests = validSamples.slice(0, sampleCount)
   const avgOfLowests = lowests.reduce((acc, cur) => acc + cur.confirmationTime, 0) / lowests.length
 
   const ACCEPTABLE_CONFIRMATION_TIME = 2 * avgBlockTime


### PR DESCRIPTION
Discord fee rate samples with excessive fee rate when the
on-chain bandwidth is sufficient for low fee transactions.

This commit is generated by cursor and reviewed by @Keith-CY