### PR TITLE
fix: fix display of sudt's fullname

### DIFF
--- a/src/pages/UDT/UDTComp.tsx
+++ b/src/pages/UDT/UDTComp.tsx
@@ -90,7 +90,11 @@ export const UDTOverviewCard = ({
     ? [
         {
           title: t('udt.name'),
-          content: <div className={styles.symbolWithEllipsis}>fullName</div>,
+          content: fullName ? (
+            <div className={styles.symbolWithEllipsis}>{fullName}</div>
+          ) : (
+            <span className={styles.noneName}>(None)</span>
+          ),
         },
         {
           title: t('udt.owner'),


### PR DESCRIPTION
Before:
<img width="625" alt="image" src="https://github.com/user-attachments/assets/ac15021e-e1d9-4245-8e84-eeff428cd1ac" />

After:
<img width="619" alt="image" src="https://github.com/user-attachments/assets/9a597ffe-ab16-42cf-a728-7ffcb9f130f6" />

e.g. https://explorer.nervos.org/sudt/0x797bfd0b7b883bc9dba43678e285999507c6d0b971a2740c76623f70636f4080