### PR TITLE
fix: fix font size in the chart on the homepage

### DIFF
--- a/src/pages/Home/index.module.scss
+++ b/src/pages/Home/index.module.scss
@@ -368,9 +368,15 @@
     font-size: 20px;
     color: #fff;
     font-weight: bold;
+    &[data-is-primary='true'] {
+      font-size: 26px;
+    }
 
     @media (max-width: $extraLargeBreakPoint) {
       font-size: 18px;
+      &[data-is-primary='true'] {
+        font-size: 18px;
+      }
     }
   }
 }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -46,7 +46,7 @@ const TableMorePanel: FC<HTMLAttributes<HTMLDivElement>> = props => {
 const StatisticItem = ({ blockchain, isFirst }: { blockchain: BlockchainData; isFirst?: boolean }) => (
   <div className={`${styles.homeStatisticItemPanel} ${isFirst ? styles.isFirst : ''}`}>
     <div className="homeStatisticItemName">{blockchain.name}</div>
-    <div className="homeStatisticItemValue" style={{ fontSize: isFirst ? '26px' : '20px' }}>
+    <div className="homeStatisticItemValue" data-is-primary={isFirst}>
       {blockchain.value}
     </div>
   </div>


### PR DESCRIPTION
Before
<img width="980" height="244" alt="Pasted Graphic 17" src="https://github.com/user-attachments/assets/d711827f-de04-4adf-9d12-698902b5addd" />
<img width="384" height="246" alt="Latest Block" src="https://github.com/user-attachments/assets/e3595190-75d2-4acb-825c-50a86355eb7b" />
After
<img width="1068" height="232" alt="Pasted Graphic 12" src="https://github.com/user-attachments/assets/a440ccba-d743-4333-9ede-1df376a9ff44" />
<img width="370" height="200" alt="Latest Block" src="https://github.com/user-attachments/assets/59cd7149-6502-4a49-910d-178b56fde5a5" />
