### PR TITLE
fix: hide hashtag if tag is empty

### DIFF
--- a/src/components/HashTag/index.tsx
+++ b/src/components/HashTag/index.tsx
@@ -10,7 +10,7 @@ export default ({ script }: { script: Script & { category?: 'lock' | 'type' } })
 
   if (isTypeIdScript(script)) {
     hashTag = { tag: TYPE_ID_TAG, category: 'type' }
-  } else {
+  } else if (script.tags?.length) {
     hashTag = {
       tag: script.tags?.[0] ?? '',
       category: scriptType ?? script.category,


### PR DESCRIPTION
Before:
<img width="1728" height="404" alt="image" src="https://github.com/user-attachments/assets/11e05ea1-3b99-4148-928b-98b9dce43e7c" />

After:
<img width="1854" height="830" alt="image" src="https://github.com/user-attachments/assets/a08a9888-0595-4e97-8a52-97afef72c59e" />
