### PR TITLE
feat: add fallback when spore collection type hash is missing

### DIFF
--- a/src/pages/Transaction/TransactionCell/index.tsx
+++ b/src/pages/Transaction/TransactionCell/index.tsx
@@ -546,11 +546,14 @@ export const TransactionCellDetail = ({ cell }: { cell: Cell }) => {
     }
     case 'did_cell':
     case 'spore_cell': {
-      detailTitle = (
-        <Link to={`/dob-collections/${cell.extraInfo?.collection.typeHash}`}>
-          {cell.extraInfo?.clusterName || 'Unique Item'}
-        </Link>
-      )
+      const collectionId = cell.extraInfo?.collection?.typeHash
+      if (collectionId) {
+        detailTitle = (
+          <Link to={`/dob-collections/${collectionId}`}>{cell.extraInfo?.clusterName || 'Unique Item'}</Link>
+        )
+      } else {
+        detailTitle = cell.extraInfo?.clusterName || 'Unique Item'
+      }
       detailIcon = dobInfo.cover
       tooltip = nftInfo
       break


### PR DESCRIPTION
This commit adds a fallback for spore cells whose collection type hash is missing in the API

A spore cell is expected to have
```
{
  extra_info: {
    collection: {
      type_hash: "..."
    }
  }
}
```
where "extra_info.collection.type_hash" is the "spore collection type hash" used in links to the collection page

But in some case the "collection" field is missing and leads to page crash.

This commit adds a fallback to replace the link with plain text so the page won't crash

Ref: https://testnet.explorer.nervos.org/transaction/0xa2967e0598aea5a63ff2c9b8949776ca880e2d094f4f3eef3cc45fcde845575d