### PR TITLE
feat: render application/ckbfs Spore DOBs

### DIFF
--- a/src/utils/spore.ts
+++ b/src/utils/spore.ts
@@ -95,12 +95,131 @@ export const getSporeImg = async ({ data: hexData, id: sporeId }: { data: string
       return DEFAULT_URL
     }
   }
+  if (contentType === 'application/ckbfs') {
+    try {
+      // content is hex-encoded "ckbfs://0x<typeId>" string
+      const ckbfsUri = hexToUtf8(`0x${content}`)
+      const typeId = ckbfsUri.replace(/^ckbfs:\/\//, '')
+      const img = await resolveCKBFSImage(typeId)
+      if (img) return img
+    } catch {
+      // fall through to placeholder
+    }
+  }
   if (contentType.startsWith('dob/')) {
     const renderRes = await renderByTokenKey(sporeId.slice(2))
     const base64Img = await svgToBase64(renderRes)
     return base64Img
   }
   return DEFAULT_URL
+}
+
+/**
+ * Resolve a CKBFS TypeID to a base64 data URL for inline image display.
+ * Fetches the CKBFS index cell, then reassembles file bytes from witnesses.
+ * Supports multi-chunk files (Vec<Uint32> indexes in cell data).
+ */
+async function resolveCKBFSImage(typeId: string): Promise<string | null> {
+  const CKBFS_CODE_HASH = '0x31e6376287d223b8c0410d562fb422f04d1d617b2947596a14c3d2efb7218d3a'
+  const rpcUrl = isMainnet() ? 'https://mainnet.ckbapp.dev' : 'https://testnet.ckbapp.dev'
+
+  const rpc = async (method: string, params: unknown[]) => {
+    const res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: 1, jsonrpc: '2.0', method, params }),
+    })
+    const data = await res.json()
+    if (data.error) throw new Error(data.error.message)
+    return data.result
+  }
+
+  // Find live CKBFS index cell
+  const cellsResult = await rpc('get_cells', [
+    { script: { code_hash: CKBFS_CODE_HASH, hash_type: 'data1', args: typeId }, script_type: 'type', filter: null },
+    'asc',
+    '0x1',
+  ])
+  const cells = cellsResult?.objects ?? []
+  if (!cells.length) return null
+
+  const cell = cells[0]
+  const meta = decodeCKBFSData(cell.output_data ?? '0x')
+  if (!meta.contentType.startsWith('image/')) return null
+
+  // Fetch publish transaction
+  const txResult = await rpc('get_transaction', [cell.out_point.tx_hash])
+  const witnesses: string[] = txResult?.transaction?.witnesses ?? []
+
+  // Reassemble all chunks (multi-chunk support)
+  const chunks: Uint8Array[] = []
+  for (const idx of meta.indexes) {
+    if (idx >= witnesses.length) return null
+    const chunk = extractCKBFSChunk(witnesses[idx])
+    if (!chunk) return null
+    chunks.push(chunk)
+  }
+
+  const totalLen = chunks.reduce((s, c) => s + c.length, 0)
+  const fileBytes = new Uint8Array(new ArrayBuffer(totalLen))
+  let offset = 0
+  for (const chunk of chunks) { fileBytes.set(chunk, offset); offset += chunk.length }
+
+  // Convert to base64 data URL
+  let binary = ''
+  for (let i = 0; i < fileBytes.length; i++) binary += String.fromCharCode(fileBytes[i])
+  return `data:${meta.contentType};base64,${btoa(binary)}`
+}
+
+interface CKBFSMeta {
+  indexes: number[]
+  contentType: string
+  filename: string
+}
+
+function decodeCKBFSData(hex: string): CKBFSMeta {
+  const raw = hexBytes(hex)
+  const buf = raw.buffer.slice(raw.byteOffset, raw.byteOffset + raw.byteLength)
+  const dv = new DataView(buf)
+
+  const firstOffset = dv.getUint32(4, true)
+  const fieldCount = firstOffset / 4 - 1
+  const offsets: number[] = []
+  for (let i = 0; i < fieldCount; i++) offsets.push(dv.getUint32(4 + i * 4, true))
+  offsets.push(dv.getUint32(0, true))
+
+  const readStr = (off: number) => {
+    const len = dv.getUint32(off, true)
+    return new TextDecoder().decode(new Uint8Array(buf, off + 4, len))
+  }
+
+  if (fieldCount === 4) {
+    // index: Uint32, checksum: Uint32, content_type: Bytes, filename: Bytes
+    return { indexes: [dv.getUint32(offsets[0], true)], contentType: readStr(offsets[2]), filename: readStr(offsets[3]) }
+  }
+  // indexes: Vec<Uint32>, checksum: Uint32, content_type: Bytes, filename: Bytes, backlinks
+  const idxBuf = buf.slice(offsets[0], offsets[1])
+  const idxDv = new DataView(idxBuf)
+  const count = idxDv.getUint32(0, true)
+  const indexes: number[] = []
+  for (let i = 0; i < count; i++) indexes.push(idxDv.getUint32(4 + i * 4, true))
+  return { indexes, contentType: readStr(offsets[2]), filename: readStr(offsets[3]) }
+}
+
+function extractCKBFSChunk(witnessHex: string): Uint8Array | null {
+  const bytes = hexBytes(witnessHex)
+  const magic = new TextDecoder().decode(bytes.slice(0, 5))
+  if (magic !== 'CKBFS') return null
+  const version = bytes[5]
+  return bytes.slice(version === 0x03 ? 50 : 6)
+}
+
+function hexBytes(hex: string): Uint8Array {
+  const h = hex.startsWith('0x') ? hex.slice(2) : hex
+  const buf = new ArrayBuffer(h.length / 2)
+  const b = new Uint8Array(buf)
+  for (let i = 0; i < b.length; i++) b[i] = parseInt(h.slice(i * 2, i * 2 + 2), 16)
+  return b
 }
 
 export const isDob0 = (item: { standard: string | null; cell: { data: string | null } | null }) => {


### PR DESCRIPTION
## Summary

Adds CKBFS (CKB File Storage) resolution support to `getSporeImg()`. Spore DOBs with `contentType: application/ckbfs` currently show a placeholder in the explorer — this PR makes them render their actual image.

## How CKBFS works

CKBFS stores file content in transaction witnesses (prunable, but always accessible via RPC). A small index cell with a TypeID identifies the file. DOBs reference it with a `ckbfs://0x<typeId>` URI in their content field.

## What this change does

When `getSporeImg` encounters `contentType === 'application/ckbfs'`:

1. Parses the `ckbfs://0x<typeId>` URI from the DOB content
2. Queries the live CKBFS index cell by TypeID (`code_hash: 0x31e637...`)
3. Decodes the molecule-encoded cell data to get witness index(es), content type, and filename
4. Fetches the publish transaction and extracts file bytes from the indexed witnesses
5. Reassembles multi-chunk files (large files span multiple witnesses)
6. Returns a base64 data URL for inline display

On any resolution failure, falls through gracefully to the existing placeholder.

## Schema support

Handles both deployed CKBFS cell data schemas:
- **4-field** (V2 contract, `index: Uint32`): single witness index
- **5-field** (older V2, `indexes: Vec<Uint32>`): multiple witness indexes for chunked files

## Network support

Uses `isMainnet()` to select the correct CKB RPC endpoint (mainnet.ckbapp.dev / testnet.ckbapp.dev).

## Testing

Testnet DOB with CKBFS content: tx `0x5a013e22fa64644bfd2610c4665d54de4dbab2b5ec77e1965882f1ddebbe4c66`
CKBFS TypeID: `0x061cc843e720a4274da71a1a2fec4802cd02f6d5ee7167e7429435878068abe0`

Live resolver demo: https://wyltekindustries.com/ckbfs-viewer.html?id=0x061cc843e720a4274da71a1a2fec4802cd02f6d5ee7167e7429435878068abe0&net=testnet

## Protocol reference

- CKBFS: https://github.com/code-monad/ckbfs
- SDK: https://github.com/nervape/ckbfs-api