### PR TITLE
fix: hide hardfork banner and align dob-render test config

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -140,7 +140,9 @@ module.exports = {
     };
   },
   jest: config => {
-    config.transformIgnorePatterns = ['node_modules/(?!(camelcase-keys|map-obj|camelcase|quick-lru|@joyid/common)/)']
+    config.transformIgnorePatterns = [
+      'node_modules/(?!(camelcase-keys|map-obj|camelcase|quick-lru|@joyid/common|@nervape/dob-render|@nervina-labs/dob-render)/)',
+    ]
     return config
   },
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,12 +2,17 @@ const { TextEncoder, TextDecoder } = require('util')
 global.TextEncoder = TextEncoder
 global.TextDecoder = TextDecoder
 
-// Mock @nervina-labs/dob-render
-jest.mock('@nervina-labs/dob-render', () => ({
+const mockDobRenderModule = {
   config: {
     setDobDecodeServerURL: jest.fn(),
     setQueryBtcFsFn: jest.fn(),
   },
   renderByTokenKey: jest.fn(),
   svgToBase64: jest.fn()
-}))
+}
+
+// Keep both package names mocked because the codebase was migrated from
+// @nervina-labs/dob-render to @nervape/dob-render and tests still rely on the
+// renderer being stubbed out.
+jest.mock('@nervape/dob-render', () => mockDobRenderModule)
+jest.mock('@nervina-labs/dob-render', () => mockDobRenderModule)

--- a/package.json
+++ b/package.json
@@ -134,13 +134,14 @@
     "displayName": "Unit Test",
     "moduleNameMapper": {
       "axios": "axios/dist/node/axios.cjs",
+      "@nervape/dob-render": "<rootDir>/node_modules/@nervape/dob-render/dist/index.js",
       "@nervina-labs/dob-render": "<rootDir>/node_modules/@nervina-labs/dob-render/dist/index.js"
     },
     "setupFilesAfterEnv": [
       "<rootDir>/jest.setup.js"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!(@nervina-labs/dob-render)/)"
+      "node_modules/(?!(@nervape/dob-render|@nervina-labs/dob-render)/)"
     ]
   },
   "browserslist": [

--- a/src/pages/Home/Banner/index.tsx
+++ b/src/pages/Home/Banner/index.tsx
@@ -43,7 +43,7 @@ export default () => {
     {
       key: 'hardfork',
       component: <HardforkBanner />,
-      isHidden: !IS_MAINNET,
+      isHidden: true,
     },
     {
       key: 'knowledge',


### PR DESCRIPTION
## Intent
- remove the hardfork banner from the homepage as requested
- fix the Jest and GitHub Actions failures caused by the dob-render package switch

## Scope
- hide the hardfork banner in the home banner carousel
- align Jest mocks with both dob-render package names
- align Jest moduleNameMapper and transformIgnorePatterns with the new package name
- keep the react-app-rewired Jest transform allowlist consistent with the package switch

## Validation
- normal git commit completed with hooks enabled
- yarn test passed in the commit hook: 10 suites, 66 tests