### PR TITLE
chore: update auto-merge reviewer to rivjc1025

### DIFF
--- a/.github/workflows/auto_merge_request.yml
+++ b/.github/workflows/auto_merge_request.yml
@@ -17,7 +17,7 @@ jobs:
           source_branch: 'develop'
           destination_branch: 'testnet'
           pr_title: 'Merge develop into testnet'
-          pr_reviewer: 'walker27'
+          pr_reviewer: 'rivjc1025'
           pr_label: 'auto-pr'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -32,7 +32,7 @@ jobs:
           source_branch: 'testnet'
           destination_branch: 'master'
           pr_title: 'Merge testnet into mainnet'
-          pr_reviewer: 'walker27'
+          pr_reviewer: 'rivjc1025'
           pr_label: 'auto-pr'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -47,6 +47,6 @@ jobs:
           source_branch: 'master'
           destination_branch: 'develop'
           pr_title: 'Merge mainnet into develop'
-          pr_reviewer: 'walker27'
+          pr_reviewer: 'rivjc1025'
           pr_label: 'auto-pr'
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update the auto-merge workflow to request reviews from `rivjc1025`
- keep the existing develop -> testnet -> master branch sync flow unchanged

## Why
- the current auto-merge workflow is failing when it tries to request `walker27` as reviewer
- this change switches the reviewer to the current valid account requested for the workflow

## Validation
- `react-app-rewired test --watchAll=false`
