### PR TITLE
fix: update fiber official website link

### DIFF
--- a/src/constants/scripts.ts
+++ b/src/constants/scripts.ts
@@ -383,7 +383,7 @@ export const scripts = new Map<string, ScriptAttributes>([
     {
       name: 'Fiber Channel',
       description: 'Fiber Channel',
-      website: 'https://www.ckbfiber.net',
+      website: 'https://www.fiber.world',
     },
   ],
 ])

--- a/src/pages/Fiber/Graph/index.tsx
+++ b/src/pages/Fiber/Graph/index.tsx
@@ -82,7 +82,7 @@ const FiberBanner = ({ t }: { t: (key: string) => string }) => (
       <h3>{t('banner.fiber_subtitle')}</h3>
     </div>
     <div className={styles.links}>
-      <Link to="https://www.ckbfiber.net/" target="_blank" rel="noopener noreferrer">
+      <Link to="https://www.fiber.world/" target="_blank" rel="noopener noreferrer">
         <span>{t('banner.learn_more')}</span>
       </Link>
     </div>

--- a/src/pages/Home/Banner/index.tsx
+++ b/src/pages/Home/Banner/index.tsx
@@ -78,7 +78,7 @@ export default () => {
             <h3>{t(`banner.fiber_subtitle`)}</h3>
           </div>
           <div className={styles.links}>
-            <Link to="https://www.ckbfiber.net/" target="_blank" rel="noopener noreferrer">
+            <Link to="https://www.fiber.world/" target="_blank" rel="noopener noreferrer">
               <span>{t(`banner.learn_more`)}</span>
             </Link>
             <Tooltip


### PR DESCRIPTION
Replace the unreachable Fiber official website link `https://www.ckbfiber.net` with `https://www.fiber.world/`.\n\nUpdated in:\n- `src/pages/Home/Banner/index.tsx`\n- `src/pages/Fiber/Graph/index.tsx`\n- `src/constants/scripts.ts`\n\n🤖 Generated with [Claude Code](https://claude.com/code)